### PR TITLE
Hotfix: role/permission middleware broken after spatie/laravel-permission v6

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -70,9 +70,9 @@ class Kernel extends HttpKernel
         'reconnect' => \App\Http\Middleware\Reconnect::class,
         'reconnectdbdefault' => \App\Http\Middleware\ReconnectDbDefault::class,
         'reconnectbeforelogin' => \App\Http\Middleware\ReconnectBeforeLogin::class,
-        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
-        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
-        'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
+        'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
         'accesses_matriz' => \App\Http\Middleware\RouteAccessesMatriz::class,
         'accesses_filial' => \App\Http\Middleware\RouteAccessesFilial::class,
 

--- a/tests/Feature/PermissionMiddlewareRegressionTest.php
+++ b/tests/Feature/PermissionMiddlewareRegressionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Entities\TbBase;
+use App\Entities\TbCadUser;
+use App\Entities\TbProfile;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+/**
+ * Regressão: app/Http/Kernel.php registrava os aliases 'role'/'permission'/
+ * 'role_or_permission' apontando para Spatie\Permission\Middlewares\* (plural),
+ * namespace removido no spatie/laravel-permission 6.x (agora é Middleware,
+ * singular). Qualquer rota gateada por esses middlewares (ex: /launchs-cl,
+ * /roles) retornava 500 (BindingResolutionException) em produção.
+ */
+class PermissionMiddlewareRegressionTest extends TestCase
+{
+    private function makeUserWithPermission(string $permission): TbCadUser
+    {
+        Permission::findOrCreate($permission, 'web');
+
+        $base = TbBase::firstOrCreate(['sigla' => 'MTZ'], ['name' => 'Matriz']);
+        $profile = TbProfile::firstOrCreate(['name' => 'Administrador']);
+
+        $user = TbCadUser::firstOrCreate(
+            ['email' => 'permtest@example.com'],
+            [
+                'name' => 'Permission Test',
+                'idtb_profile' => $profile->id,
+                'idtb_base' => $base->id,
+                'password' => bcrypt('secret'),
+                'status' => 1,
+            ]
+        );
+
+        if (! $user->hasPermissionTo($permission)) {
+            $user->givePermissionTo($permission);
+        }
+
+        return $user;
+    }
+
+    public function test_permission_gated_route_does_not_throw_binding_resolution_exception(): void
+    {
+        $user = $this->makeUserWithPermission('launch-list');
+
+        $this->withoutExceptionHandling();
+
+        $this->actingAs($user)
+            ->withSession(['user' => ['id' => $user->id]])
+            ->get('/launchs-cl')
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary

Production is currently throwing 500s (`BindingResolutionException: Target class [Spatie\Permission\Middlewares\PermissionMiddleware] does not exist.`) on `/launchs-cl` and likely every other route gated by the `role`/`permission`/`role_or_permission` middleware aliases — reported via Flare.

## Root cause

PR #135 bumped `spatie/laravel-permission` from `^5.1` to `^6.0`. That major version renamed the middleware namespace from `Spatie\Permission\Middlewares\*` (plural) to `Spatie\Permission\Middleware\*` (singular) — confirmed against the installed `vendor/spatie/laravel-permission/src/Middleware/*.php`, the plural namespace no longer exists. `app/Http/Kernel.php` was never updated to match, so the three aliases pointed at classes that don't exist anymore:

```php
'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
```

These three aliases are used by 16 controllers (`RoleController`, `PermissionController`, `TbLaunchController`, `TbCadUsersController`, `TbCaixasController`, `TbClosingsController`, `TbBasesController`, `TbPaymentTypesController`, `TbProfilesController`, `TbTypeLaunchesController`, `TbTypeLauncsController`, `DashboardController`, `PdfController`, and the `Api/*` equivalents), so this affected essentially every permission-gated action in the app, not just `/launchs-cl`.

## Fix

One-line-per-alias rename in `app/Http/Kernel.php` to the singular `Middleware` namespace.

## Test plan

- [x] Added `tests/Feature/PermissionMiddlewareRegressionTest.php`, which hits `/launchs-cl` (gated by `permission:launch-list`) with an authenticated, permitted user
- [x] Confirmed the test reproduces the exact reported error against the old (plural) namespace, then passes against the fix
- [x] `php artisan test` — full suite green aside from a pre-existing, unrelated failure (`ExampleTest` needs a real MySQL connection to render the homepage; not something this sandbox or this PR can fix)

https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH

---
_Generated by [Claude Code](https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH)_