### PR TITLE
Standardize Filament forms (Section+columns(2)), navigation groups, and Roles↔Permissions relation manager

### DIFF
--- a/app/Filament/Resources/PermissionsResource.php
+++ b/app/Filament/Resources/PermissionsResource.php
@@ -17,9 +17,9 @@ class PermissionsResource extends Resource
 {
     protected static ?string $model = Permissions::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-key';
 
-    protected static ?string $navigationGroup = 'Configurações';
+    protected static ?string $navigationGroup = 'Segurança';
 
     protected static ?string $navigationLabel = 'Permissões';
 
@@ -36,12 +36,17 @@ class PermissionsResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
-                    ->label('Nome')
-                    ->required(),
-                Forms\Components\TextInput::make('guard_name')
-                    ->label('Guard')
-                    ->required(),
+                Forms\Components\Section::make('Dados da Permissão')
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nome')
+                            ->required(),
+                        Forms\Components\TextInput::make('guard_name')
+                            ->label('Guard')
+                            ->required(),
+                    ])
+                    ->columns(2)
+                    ->columnSpanFull(),
             ]);
     }
 

--- a/app/Filament/Resources/RolesResource.php
+++ b/app/Filament/Resources/RolesResource.php
@@ -17,9 +17,9 @@ class RolesResource extends Resource
 {
     protected static ?string $model = Roles::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-shield-check';
 
-    protected static ?string $navigationGroup = 'Configurações';
+    protected static ?string $navigationGroup = 'Segurança';
 
     protected static ?string $navigationLabel = 'Perfis de Acesso';
 
@@ -36,12 +36,17 @@ class RolesResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
-                    ->label('Nome')
-                    ->required(),
-                Forms\Components\TextInput::make('guard_name')
-                    ->label('Guard')
-                    ->required(),
+                Forms\Components\Section::make('Dados do Perfil de Acesso')
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nome')
+                            ->required(),
+                        Forms\Components\TextInput::make('guard_name')
+                            ->label('Guard')
+                            ->required(),
+                    ])
+                    ->columns(2)
+                    ->columnSpanFull(),
             ]);
     }
 
@@ -87,7 +92,7 @@ class RolesResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            RelationManagers\PermissionsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/RolesResource/RelationManagers/PermissionsRelationManager.php
+++ b/app/Filament/Resources/RolesResource/RelationManagers/PermissionsRelationManager.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Filament\Resources\RolesResource\RelationManagers;
+
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+/**
+ * Reproduz, via Filament, a atribuição de permissões a uma role que hoje é
+ * feita no fluxo legado (resources/views/user/roles.blade.php +
+ * RoleService::store/update, via $role->syncPermissions()). Usa
+ * attach/detach sobre permissões já existentes — não cria/edita/apaga a
+ * Permission em si (isso é papel do PermissionsResource).
+ *
+ * Limitação conhecida: RoleService também propaga a role para as bases das
+ * filiais via App\Services\ReplicaDbService, o que este RelationManager
+ * ainda não reproduz. Ver plano de reconciliação antes de desativar a tela
+ * legada de roles.
+ */
+class PermissionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'permissions';
+
+    protected static ?string $title = 'Permissões';
+
+    protected static ?string $modelLabel = 'Permissão';
+
+    protected static ?string $pluralModelLabel = 'Permissões';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('name')
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Nome')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('guard_name')
+                    ->label('Guard')
+                    ->searchable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                Tables\Actions\AttachAction::make()
+                    ->label('Atribuir Permissão')
+                    ->recordSelectSearchColumns(['name'])
+                    ->preloadRecordSelect(),
+            ])
+            ->actions([
+                Tables\Actions\DetachAction::make()
+                    ->label('Remover'),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DetachBulkAction::make()
+                        ->label('Remover selecionadas'),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/TbBaseResource.php
+++ b/app/Filament/Resources/TbBaseResource.php
@@ -17,9 +17,9 @@ class TbBaseResource extends Resource
 {
     protected static ?string $model = TbBase::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-building-office-2';
 
-    protected static ?string $navigationGroup = 'Configurações';
+    protected static ?string $navigationGroup = 'Estrutura Organizacional';
 
     protected static ?string $navigationLabel = 'Bases';
 
@@ -36,14 +36,19 @@ class TbBaseResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
-                    ->label('Nome')
-                    ->required(),
-                Forms\Components\TextInput::make('sigla')
-                    ->label('Sigla')
-                    ->required(),
-                Forms\Components\Textarea::make('descripion')
-                    ->label('Descrição')
+                Forms\Components\Section::make('Dados da Base')
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nome')
+                            ->required(),
+                        Forms\Components\TextInput::make('sigla')
+                            ->label('Sigla')
+                            ->required(),
+                        Forms\Components\Textarea::make('descripion')
+                            ->label('Descrição')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2)
                     ->columnSpanFull(),
             ]);
     }

--- a/app/Filament/Resources/TbCaixaResource.php
+++ b/app/Filament/Resources/TbCaixaResource.php
@@ -17,9 +17,9 @@ class TbCaixaResource extends Resource
 {
     protected static ?string $model = TbCaixa::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-archive-box';
 
-    protected static ?string $navigationGroup = 'Configurações';
+    protected static ?string $navigationGroup = 'Configurações Financeiras';
 
     protected static ?string $navigationLabel = 'Caixas';
 
@@ -36,11 +36,16 @@ class TbCaixaResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
-                    ->label('Nome')
-                    ->required(),
-                Forms\Components\Textarea::make('description')
-                    ->label('Descrição')
+                Forms\Components\Section::make('Dados da Caixa')
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nome')
+                            ->required(),
+                        Forms\Components\Textarea::make('description')
+                            ->label('Descrição')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2)
                     ->columnSpanFull(),
             ]);
     }

--- a/app/Filament/Resources/TbOperationResource.php
+++ b/app/Filament/Resources/TbOperationResource.php
@@ -17,9 +17,9 @@ class TbOperationResource extends Resource
 {
     protected static ?string $model = TbOperation::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-arrows-right-left';
 
-    protected static ?string $navigationGroup = 'Configurações';
+    protected static ?string $navigationGroup = 'Configurações Financeiras';
 
     protected static ?string $navigationLabel = 'Operações';
 
@@ -36,11 +36,16 @@ class TbOperationResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
-                    ->label('Nome')
-                    ->required(),
-                Forms\Components\Textarea::make('descripion')
-                    ->label('Descrição')
+                Forms\Components\Section::make('Dados da Operação')
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nome')
+                            ->required(),
+                        Forms\Components\Textarea::make('descripion')
+                            ->label('Descrição')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2)
                     ->columnSpanFull(),
             ]);
     }

--- a/app/Filament/Resources/TbPaymentTypeResource.php
+++ b/app/Filament/Resources/TbPaymentTypeResource.php
@@ -17,9 +17,9 @@ class TbPaymentTypeResource extends Resource
 {
     protected static ?string $model = TbPaymentType::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-credit-card';
 
-    protected static ?string $navigationGroup = 'Configurações';
+    protected static ?string $navigationGroup = 'Configurações Financeiras';
 
     protected static ?string $navigationLabel = 'Tipos de Pagamento';
 
@@ -36,11 +36,16 @@ class TbPaymentTypeResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
-                    ->label('Nome')
-                    ->required(),
-                Forms\Components\Textarea::make('descripion')
-                    ->label('Descrição')
+                Forms\Components\Section::make('Dados do Tipo de Pagamento')
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nome')
+                            ->required(),
+                        Forms\Components\Textarea::make('descripion')
+                            ->label('Descrição')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2)
                     ->columnSpanFull(),
             ]);
     }

--- a/app/Filament/Resources/TbTypeLaunchResource.php
+++ b/app/Filament/Resources/TbTypeLaunchResource.php
@@ -17,9 +17,9 @@ class TbTypeLaunchResource extends Resource
 {
     protected static ?string $model = TbTypeLaunch::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-tag';
 
-    protected static ?string $navigationGroup = 'Configurações';
+    protected static ?string $navigationGroup = 'Configurações Financeiras';
 
     protected static ?string $navigationLabel = 'Tipos de Lançamento';
 
@@ -36,11 +36,16 @@ class TbTypeLaunchResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('name')
-                    ->label('Nome')
-                    ->required(),
-                Forms\Components\Textarea::make('descripion')
-                    ->label('Descrição')
+                Forms\Components\Section::make('Dados do Tipo de Lançamento')
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nome')
+                            ->required(),
+                        Forms\Components\Textarea::make('descripion')
+                            ->label('Descrição')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2)
                     ->columnSpanFull(),
             ]);
     }

--- a/tests/Feature/RolesPermissionsRelationManagerTest.php
+++ b/tests/Feature/RolesPermissionsRelationManagerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Entities\TbBase;
+use App\Entities\TbCadUser;
+use App\Entities\TbProfile;
+use App\Filament\Resources\RolesResource\RelationManagers\PermissionsRelationManager;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class RolesPermissionsRelationManagerTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $path = dirname(__DIR__, 2) . '/database/testing.sqlite';
+        if (! file_exists($path)) {
+            touch($path);
+            (new \PDO('sqlite:' . $path))->exec('PRAGMA journal_mode=WAL');
+        }
+
+        $env = 'DB_CONNECTION_MTZ=sqlite DB_DATABASE=database/testing.sqlite APP_ENV=testing';
+        exec("{$env} php artisan migrate --path=database/migrations --force 2>&1");
+        exec("{$env} php artisan migrate --path=database/migrations/only_bd_mtz --force 2>&1");
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['database.connections.adb_mtz' => config('database.connections.sqlite')]);
+    }
+
+    private function makeAdmin(): TbCadUser
+    {
+        Role::findOrCreate('Admin', 'web');
+
+        $base = TbBase::firstOrCreate(['sigla' => 'MTZ'], ['name' => 'Matriz']);
+        $profile = TbProfile::firstOrCreate(['name' => 'Administrador']);
+
+        $user = TbCadUser::firstOrCreate(
+            ['email' => 'reltest@example.com'],
+            [
+                'name' => 'Relation Test',
+                'idtb_profile' => $profile->id,
+                'idtb_base' => $base->id,
+                'password' => bcrypt('secret'),
+                'status' => 1,
+            ]
+        );
+
+        if (! $user->hasRole('Admin')) {
+            $user->assignRole('Admin');
+        }
+
+        return $user;
+    }
+
+    public function test_role_edit_page_loads_with_permissions_relation_manager(): void
+    {
+        $admin = $this->makeAdmin();
+        $role = Role::findOrCreate('Financeiro', 'web');
+
+        $this->actingAs($admin)
+            ->get("/admin/roles/{$role->id}/edit")
+            ->assertStatus(200)
+            ->assertSeeLivewire(PermissionsRelationManager::class);
+    }
+
+    public function test_can_attach_and_detach_permission_via_relation_manager(): void
+    {
+        $admin = $this->makeAdmin();
+        $role = Role::findOrCreate('Tesoureiro', 'web');
+        $permission = Permission::findOrCreate('launch-list', 'web');
+
+        $this->actingAs($admin);
+
+        Livewire::test(PermissionsRelationManager::class, [
+            'ownerRecord' => $role,
+            'pageClass' => \App\Filament\Resources\RolesResource\Pages\EditRoles::class,
+        ])
+            ->callTableAction('attach', null, data: ['recordId' => $permission->id])
+            ->assertHasNoTableActionErrors();
+
+        $this->assertTrue($role->fresh()->hasPermissionTo('launch-list'));
+
+        Livewire::test(PermissionsRelationManager::class, [
+            'ownerRecord' => $role,
+            'pageClass' => \App\Filament\Resources\RolesResource\Pages\EditRoles::class,
+        ])
+            ->callTableAction('detach', $permission)
+            ->assertHasNoTableActionErrors();
+
+        $this->assertFalse($role->fresh()->hasPermissionTo('launch-list'));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up polish on the Filament admin panel (7 resources from PR #135), requested after reviewing the panel in production:

1. **Form layout**: every resource's `form()` now wraps its fields in a full-width `Section` using `columns(2)`, instead of a flat field list. Short fields (name/sigla/guard_name) sit side by side; long text fields (`descripion`/`description`) stay full width below.
2. **Navigation groups**: split the single `'Configurações'` group (shared by all 7, with the same icon) into three, each with a distinct icon:
   - **Segurança**: Roles (`heroicon-o-shield-check`), Permissions (`heroicon-o-key`)
   - **Estrutura Organizacional**: Bases (`heroicon-o-building-office-2`)
   - **Configurações Financeiras**: Caixas (`heroicon-o-archive-box`), Operações (`heroicon-o-arrows-right-left`), Tipos de Pagamento (`heroicon-o-credit-card`), Tipos de Lançamento (`heroicon-o-tag`)
3. **RolesResource permissions RelationManager**: adds attach/detach of permissions to a role, using the `permissions()` relation already inherited from `Spatie\Permission\Models\Role` — no new relation needed on the Entity.

## Why the relation manager, and what it does *not* fix

The legacy `resources/views/user/roles.blade.php` screen treats assigning permissions to a role as **mandatory** (`RoleService::store/update` calls `$role->syncPermissions()`, and the legacy form validates `permission` as `required`). The Filament `RolesResource` had no way to do this at all — no field, no relation manager. This PR closes that specific gap.

It does **not** yet make the Filament `RolesResource` a full replacement for the legacy screen: `RoleService::store/update/delete` also propagates role changes to filial databases via `App\Services\ReplicaDbService`, which this relation manager doesn't reproduce. Both UIs should keep coexisting until that's addressed — not in scope here.

## Test plan

- [x] `php artisan test` — full suite green aside from the pre-existing, unrelated `ExampleTest` failure (needs a real MySQL connection to render the homepage)
- [x] Added `tests/Feature/RolesPermissionsRelationManagerTest.php`: confirms the role edit page renders with the `PermissionsRelationManager` Livewire component, and that attach/detach actually update the role's permissions (`hasPermissionTo()` before/after)
- [x] `php -l` on every changed file

https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH

---
_Generated by [Claude Code](https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH)_