### PR TITLE
Fase E: seleção de filial no painel + Lançamentos unificados no Filament

### DIFF
--- a/app/Entities/TbBase.php
+++ b/app/Entities/TbBase.php
@@ -29,7 +29,7 @@ class TbBase extends Model implements Transformable
      */
     public     $timestamps   = true;
     protected  $table        = 'tb_base';
-    protected $fillable = ['id', 'name', 'sigla', 'descripion'];
+    protected $fillable = ['id', 'name', 'sigla', 'descripion', 'id_mtz'];
     //Alterando nome do evento 
     protected static $logName                      = 'TbBase';
     //vevntos que acionan o log

--- a/app/Entities/TbCadUser.php
+++ b/app/Entities/TbCadUser.php
@@ -74,6 +74,14 @@ class TbCadUser extends Authenticatable implements FilamentUser
         return $this->belongsTo(TbBase::class, 'idtb_base', 'id');
     }
 
+    // Bases (filiais) que este usuário está autorizado a selecionar no painel Filament,
+    // além da sua base principal (idtb_base). Não confundir com base(): aquela é a
+    // filial "de casa" do usuário; esta é a lista de filiais que ele pode acessar.
+    public function bases()
+    {
+        return $this->belongsToMany(TbBase::class, 'user_has_base', 'user_id', 'idtb_base');
+    }
+
     public function profile()
     {
 

--- a/app/Entities/TbCaixa.php
+++ b/app/Entities/TbCaixa.php
@@ -3,6 +3,7 @@
 namespace App\Entities;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Prettus\Repository\Contracts\Transformable;
 use Prettus\Repository\Traits\TransformableTrait;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -18,10 +19,11 @@ class TbCaixa extends Model implements Transformable
 {
     use TransformableTrait;
     use LogsActivity;
+    use SoftDeletes;
 
     public     $timestamps   = true;
     protected  $table        = 'tb_caixa';
-    protected  $fillable     = ['id', 'name', 'description'];
+    protected  $fillable     = ['id', 'name', 'description', 'id_mtz'];
     //Alterando nome do evento 
     protected static $logName                      = 'TbCaixa';
     //vevntos que acionan o log

--- a/app/Entities/TbOperation.php
+++ b/app/Entities/TbOperation.php
@@ -18,13 +18,13 @@ class TbOperation extends Model implements Transformable
 
     public     $timestamps   = true;
     protected  $table        = 'tb_operation';
-    protected  $fillable     = ['id', 'name', 'description'];
-    //Alterando nome do evento 
+    protected  $fillable     = ['id', 'name', 'descripion', 'id_mtz'];
+    //Alterando nome do evento
     protected static $logName                      = 'TbOperation';
     //vevntos que acionan o log
     protected static $recordEvents                 = ['created', 'updated', 'deleted'];
     //Atributos que sera registrada a alteração
-    protected static $logAttributes                = ['id', 'name', 'description'];
+    protected static $logAttributes                = ['id', 'name', 'descripion'];
     //Atributo que sera ignorado a alteração        
     protected static $ignoreChangedAttributes      = [];
     //Registrando log apenas de atributos alterados

--- a/app/Entities/TbPaymentType.php
+++ b/app/Entities/TbPaymentType.php
@@ -19,7 +19,7 @@ class TbPaymentType extends Model implements Transformable
 
     public     $timestamps   = true;
     protected  $table        = 'tb_payment_type';
-    protected  $fillable     = ['id', 'name', 'descripion', 'created_at', 'updated_at'];
+    protected  $fillable     = ['id', 'name', 'descripion', 'id_mtz', 'created_at', 'updated_at'];
     //Alterando nome do evento 
     protected static $logName                      = 'TbPaymentType';
     //vevntos que acionan o log

--- a/app/Entities/TbTypeLaunch.php
+++ b/app/Entities/TbTypeLaunch.php
@@ -18,7 +18,7 @@ class TbTypeLaunch extends Model implements Transformable
 
     public     $timestamps   = true;
     protected  $table        = 'tb_type_launch';
-    protected  $fillable     = ['id', 'name', 'value', 'descripion', 'created_at', 'updated_at'];
+    protected  $fillable     = ['id', 'name', 'descripion', 'id_mtz', 'created_at', 'updated_at'];
     //Alterando nome do evento 
     protected static $logName                      = 'TbTypeLaunch';
     //vevntos que acionan o log

--- a/app/Filament/Pages/SelectFilial.php
+++ b/app/Filament/Pages/SelectFilial.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Filament\Support\ResolvesFilialConnection;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+
+class SelectFilial extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-building-storefront';
+
+    protected static ?string $navigationLabel = 'Selecionar Filial';
+
+    protected static ?string $title = 'Selecionar Filial';
+
+    protected static string $view = 'filament.pages.select-filial';
+
+    public ?int $idtb_base = null;
+
+    public function mount(): void
+    {
+        $this->idtb_base = ResolvesFilialConnection::currentBase()['id'] ?? null;
+        $this->form->fill(['idtb_base' => $this->idtb_base]);
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Select::make('idtb_base')
+                    ->label('Filial')
+                    ->options(fn () => ResolvesFilialConnection::availableBasesFor(auth()->user())->pluck('name', 'id'))
+                    ->required()
+                    ->native(false),
+            ]);
+    }
+
+    public function submit(): void
+    {
+        $data = $this->form->getState();
+
+        $base = ResolvesFilialConnection::availableBasesFor(auth()->user())
+            ->firstWhere('id', $data['idtb_base']);
+
+        if (! $base) {
+            Notification::make()
+                ->title('Filial inválida')
+                ->body('Você não tem acesso a essa filial.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        ResolvesFilialConnection::setCurrentBase($base);
+
+        Notification::make()
+            ->title('Filial selecionada: ' . $base->name)
+            ->success()
+            ->send();
+
+        $this->redirect(static::getUrl());
+    }
+}

--- a/app/Filament/Resources/TbBaseResource.php
+++ b/app/Filament/Resources/TbBaseResource.php
@@ -5,12 +5,16 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\TbBaseResource\Pages;
 use App\Filament\Resources\TbBaseResource\RelationManagers;
 use App\Entities\TbBase;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbBaseRepository;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class TbBaseResource extends Resource
@@ -87,7 +91,10 @@ class TbBaseResource extends Resource
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->before(function (Collection $records) {
+                            $records->each(fn (Model $record) => LookupReplication::beforeDelete($record, TbBaseRepository::class));
+                        }),
                     Tables\Actions\ForceDeleteBulkAction::make(),
                     Tables\Actions\RestoreBulkAction::make(),
                 ]),

--- a/app/Filament/Resources/TbBaseResource/Pages/CreateTbBase.php
+++ b/app/Filament/Resources/TbBaseResource/Pages/CreateTbBase.php
@@ -3,10 +3,22 @@
 namespace App\Filament\Resources\TbBaseResource\Pages;
 
 use App\Filament\Resources\TbBaseResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbBaseRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateTbBase extends CreateRecord
 {
     protected static string $resource = TbBaseResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $record = static::getModel()::create($data);
+
+        LookupReplication::afterCreate($record, $data, TbBaseRepository::class);
+
+        return $record;
+    }
 }

--- a/app/Filament/Resources/TbBaseResource/Pages/EditTbBase.php
+++ b/app/Filament/Resources/TbBaseResource/Pages/EditTbBase.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Resources\TbBaseResource\Pages;
 
 use App\Filament\Resources\TbBaseResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbBaseRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditTbBase extends EditRecord
 {
@@ -13,9 +16,19 @@ class EditTbBase extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\DeleteAction::make(),
+            Actions\DeleteAction::make()
+                ->before(fn (Model $record) => LookupReplication::beforeDelete($record, TbBaseRepository::class)),
             Actions\ForceDeleteAction::make(),
             Actions\RestoreAction::make(),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $record->update($data);
+
+        LookupReplication::afterUpdate($record, $data, TbBaseRepository::class);
+
+        return $record;
     }
 }

--- a/app/Filament/Resources/TbCaixaResource.php
+++ b/app/Filament/Resources/TbCaixaResource.php
@@ -5,12 +5,16 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\TbCaixaResource\Pages;
 use App\Filament\Resources\TbCaixaResource\RelationManagers;
 use App\Entities\TbCaixa;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbCaixaRepository;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class TbCaixaResource extends Resource
@@ -74,14 +78,19 @@ class TbCaixaResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\TrashedFilter::make(),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->before(function (Collection $records) {
+                            $records->each(fn (Model $record) => LookupReplication::beforeDelete($record, TbCaixaRepository::class));
+                        }),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
                 ]),
             ]);
     }
@@ -100,5 +109,13 @@ class TbCaixaResource extends Resource
             'create' => Pages\CreateTbCaixa::route('/create'),
             'edit' => Pages\EditTbCaixa::route('/{record}/edit'),
         ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
     }
 }

--- a/app/Filament/Resources/TbCaixaResource/Pages/CreateTbCaixa.php
+++ b/app/Filament/Resources/TbCaixaResource/Pages/CreateTbCaixa.php
@@ -3,10 +3,22 @@
 namespace App\Filament\Resources\TbCaixaResource\Pages;
 
 use App\Filament\Resources\TbCaixaResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbCaixaRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateTbCaixa extends CreateRecord
 {
     protected static string $resource = TbCaixaResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $record = static::getModel()::create($data);
+
+        LookupReplication::afterCreate($record, $data, TbCaixaRepository::class);
+
+        return $record;
+    }
 }

--- a/app/Filament/Resources/TbCaixaResource/Pages/EditTbCaixa.php
+++ b/app/Filament/Resources/TbCaixaResource/Pages/EditTbCaixa.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Resources\TbCaixaResource\Pages;
 
 use App\Filament\Resources\TbCaixaResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbCaixaRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditTbCaixa extends EditRecord
 {
@@ -13,7 +16,19 @@ class EditTbCaixa extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\DeleteAction::make(),
+            Actions\DeleteAction::make()
+                ->before(fn (Model $record) => LookupReplication::beforeDelete($record, TbCaixaRepository::class)),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $record->update($data);
+
+        LookupReplication::afterUpdate($record, $data, TbCaixaRepository::class);
+
+        return $record;
     }
 }

--- a/app/Filament/Resources/TbLaunchResource.php
+++ b/app/Filament/Resources/TbLaunchResource.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Entities\TbLaunch;
+use App\Filament\Resources\TbLaunchResource\Pages;
+use App\Filament\Support\ResolvesFilialConnection;
+use App\Http\Controllers\ConnectDbController;
+use App\Services\TbLaunchService;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Resource único para Entrada e Saída (ao contrário das duas telas
+ * separadas do sistema legado) — o Select de Operação é obrigatório e sem
+ * valor padrão, forçando quem lança a escolher explicitamente a cada vez.
+ *
+ * Os Selects de Caixa/Tipo de Pagamento/Operação/Tipo de Lançamento listam
+ * as cópias replicadas (id_mtz) da filial ativa (Fase E.0.5), não as da
+ * matriz — a conexão já está na filial quando o form é montado, então
+ * relationship() resolve isso sozinho, sem código extra.
+ *
+ * O CRUD delega para App\Services\TbLaunchService::store()/update()/delete()
+ * (já existente, já testado em produção) em vez de reimplementar a
+ * validação de negócio (bloqueio de período fechado, replicação
+ * matriz<->filial via id_filial/id_mtz).
+ */
+class TbLaunchResource extends Resource
+{
+    protected static ?string $model = TbLaunch::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-banknotes';
+
+    protected static ?string $navigationGroup = 'Configurações Financeiras';
+
+    protected static ?string $navigationLabel = 'Lançamentos';
+
+    protected static ?string $modelLabel = 'Lançamento';
+
+    protected static ?string $pluralModelLabel = 'Lançamentos';
+
+    protected static ?bool $canApproveCache = null;
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->hasRole('Admin') ?? false;
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Section::make('Dados do Lançamento')
+                    ->schema([
+                        Forms\Components\Select::make('id_user')
+                            ->label('Lançado por')
+                            ->relationship('user', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->required(),
+                        Forms\Components\Select::make('idtb_operation')
+                            ->label('Operação')
+                            ->relationship('operation', 'name')
+                            ->native(false)
+                            ->required(),
+                        Forms\Components\Select::make('idtb_type_launch')
+                            ->label('Tipo de Lançamento')
+                            ->relationship('type_launch', 'name')
+                            ->native(false)
+                            ->required(),
+                        Forms\Components\Select::make('idtb_payment_type')
+                            ->label('Tipo de Pagamento')
+                            ->relationship('payment_type', 'name')
+                            ->native(false)
+                            ->required(),
+                        Forms\Components\Select::make('idtb_caixa')
+                            ->label('Caixa')
+                            ->relationship('caixa', 'name')
+                            ->native(false)
+                            ->required(),
+                        Forms\Components\Select::make('idtb_closing')
+                            ->label('Mês de Referência')
+                            ->relationship(
+                                name: 'closing',
+                                titleAttribute: 'id',
+                                modifyQueryUsing: fn (Builder $query) => $query->whereIn('status', [1, 2]),
+                            )
+                            ->getOptionLabelFromRecordUsing(fn ($record) => $record->MonthYear)
+                            ->native(false)
+                            ->required(),
+                        Forms\Components\DatePicker::make('operation_date')
+                            ->label('Data da Coleta')
+                            ->native(false)
+                            ->required(),
+                        Forms\Components\TextInput::make('value')
+                            ->label('Valor')
+                            ->numeric()
+                            ->prefix('R$')
+                            ->required(),
+                        Forms\Components\Textarea::make('description')
+                            ->label('Descrição')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2)
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('operation_date')
+                    ->label('Data')
+                    ->date('d/m/Y')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('operation.name')
+                    ->label('Operação')
+                    ->badge()
+                    ->color(fn (TbLaunch $record) => $record->idtb_operation == 1 ? 'success' : 'danger'),
+                Tables\Columns\TextColumn::make('value')
+                    ->label('Valor')
+                    ->money('BRL')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('type_launch.name')
+                    ->label('Tipo de Lançamento'),
+                Tables\Columns\TextColumn::make('payment_type.name')
+                    ->label('Tipo de Pagamento'),
+                Tables\Columns\TextColumn::make('caixa.name')
+                    ->label('Caixa'),
+                Tables\Columns\TextColumn::make('closing.MonthYear')
+                    ->label('Mês de Referência'),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Lançado por')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Situação')
+                    ->badge()
+                    ->formatStateUsing(fn (int $state): string => match ($state) {
+                        1 => 'Aprovado',
+                        2 => 'Reprovado',
+                        default => 'Pendente',
+                    })
+                    ->color(fn (int $state): string => match ($state) {
+                        1 => 'success',
+                        2 => 'danger',
+                        default => 'warning',
+                    }),
+            ])
+            ->defaultSort('operation_date', 'desc')
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\Action::make('aprovar')
+                    ->label('Aprovar')
+                    ->icon('heroicon-o-check-circle')
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->visible(fn (TbLaunch $record): bool => $record->status != 1 && static::userCanApprove())
+                    ->action(fn (TbLaunch $record) => static::approve($record, 1)),
+                Tables\Actions\Action::make('reprovar')
+                    ->label('Reprovar')
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn (TbLaunch $record): bool => $record->status != 2 && static::userCanApprove())
+                    ->action(fn (TbLaunch $record) => static::approve($record, 2)),
+                Tables\Actions\DeleteAction::make()
+                    ->action(function (TbLaunch $record) {
+                        ResolvesFilialConnection::assertConnected();
+
+                        app(TbLaunchService::class)->delete($record->id);
+
+                        ResolvesFilialConnection::assertConnected();
+
+                        Notification::make()
+                            ->title('Lançamento excluído')
+                            ->success()
+                            ->send();
+                    }),
+            ])
+            ->bulkActions([
+                //
+            ]);
+    }
+
+    /**
+     * A permission launch-approves só existe na matriz — Roles/Permissions
+     * ficam fora da replicação (Fase E.0.5) de propósito, pra manter o
+     * controle de acesso centralizado. Checar contra a filial ativa sempre
+     * daria "false" (tabelas existem lá, mas vazias).
+     */
+    protected static function userCanApprove(): bool
+    {
+        if (static::$canApproveCache === null) {
+            app(ConnectDbController::class)->connectMatriz();
+            static::$canApproveCache = auth()->user()?->can('launch-approves') ?? false;
+            ResolvesFilialConnection::assertConnected();
+        }
+
+        return static::$canApproveCache;
+    }
+
+    protected static function approve(TbLaunch $record, int $status): void
+    {
+        ResolvesFilialConnection::assertConnected();
+
+        $result = app(TbLaunchService::class)->aprov_id([
+            'id' => $record->id,
+            'status' => $status,
+        ]);
+
+        ResolvesFilialConnection::assertConnected();
+
+        if (! $result['success']) {
+            Notification::make()
+                ->title('Não foi possível atualizar a aprovação')
+                ->body(is_array($result['messages']) ? implode(' ', $result['messages']) : $result['messages'])
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        Notification::make()
+            ->title($status === 1 ? 'Lançamento aprovado' : 'Lançamento reprovado')
+            ->success()
+            ->send();
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        ResolvesFilialConnection::assertConnected();
+
+        return parent::getEloquentQuery();
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTbLaunches::route('/'),
+            'create' => Pages\CreateTbLaunch::route('/create'),
+            'edit' => Pages\EditTbLaunch::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TbLaunchResource/Pages/CreateTbLaunch.php
+++ b/app/Filament/Resources/TbLaunchResource/Pages/CreateTbLaunch.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Filament\Resources\TbLaunchResource\Pages;
+
+use App\Entities\TbCadUser;
+use App\Filament\Resources\TbLaunchResource;
+use App\Filament\Support\ResolvesFilialConnection;
+use App\Services\TbLaunchService;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\CreateRecord;
+use Filament\Support\Exceptions\Halt;
+use Illuminate\Database\Eloquent\Model;
+
+class CreateTbLaunch extends CreateRecord
+{
+    protected static string $resource = TbLaunchResource::class;
+
+    public function mount(): void
+    {
+        ResolvesFilialConnection::assertConnected();
+
+        parent::mount();
+    }
+
+    /**
+     * Delega para TbLaunchService::store(), que já cuida de validação de
+     * negócio, bloqueio de período fechado e replicação matriz<->filial via
+     * id_filial/id_mtz — não reimplementar nada disso aqui.
+     */
+    protected function handleRecordCreation(array $data): Model
+    {
+        ResolvesFilialConnection::assertConnected();
+
+        // O validator legado exige "name" (usado historicamente como campo
+        // de autocomplete do lançador) mesmo sem persistir — sintetiza a
+        // partir do usuário escolhido no Select, já que o form usa
+        // id_user diretamente.
+        $user = TbCadUser::find($data['id_user']);
+        $data['name'] = $user?->name;
+        $data['idtb_base'] = ResolvesFilialConnection::currentBase()['id'];
+        $data['status'] = 0;
+
+        $result = ResolvesFilialConnection::withLegacyBaseSessionBridge(
+            fn () => app(TbLaunchService::class)->store($data)
+        );
+
+        if (! $result['success']) {
+            Notification::make()
+                ->title('Não foi possível salvar o lançamento')
+                ->body(is_array($result['messages']) ? implode(' ', $result['messages']) : $result['messages'])
+                ->danger()
+                ->send();
+
+            throw new Halt();
+        }
+
+        return $result['data'];
+    }
+}

--- a/app/Filament/Resources/TbLaunchResource/Pages/EditTbLaunch.php
+++ b/app/Filament/Resources/TbLaunchResource/Pages/EditTbLaunch.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Resources\TbLaunchResource\Pages;
+
+use App\Entities\TbCadUser;
+use App\Filament\Resources\TbLaunchResource;
+use App\Filament\Support\ResolvesFilialConnection;
+use App\Services\TbLaunchService;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\EditRecord;
+use Filament\Support\Exceptions\Halt;
+use Illuminate\Database\Eloquent\Model;
+
+class EditTbLaunch extends EditRecord
+{
+    protected static string $resource = TbLaunchResource::class;
+
+    public function mount(int|string $record): void
+    {
+        ResolvesFilialConnection::assertConnected();
+
+        parent::mount($record);
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        ResolvesFilialConnection::assertConnected();
+
+        $user = TbCadUser::find($data['id_user']);
+        $data['name'] = $user?->name;
+        $data['id'] = $record->getKey();
+
+        $result = app(TbLaunchService::class)->update($data);
+
+        ResolvesFilialConnection::assertConnected();
+
+        if (! $result['success']) {
+            Notification::make()
+                ->title('Não foi possível atualizar o lançamento')
+                ->body(is_array($result['messages']) ? implode(' ', $result['messages']) : $result['messages'])
+                ->danger()
+                ->send();
+
+            throw new Halt();
+        }
+
+        return $record->fresh();
+    }
+}

--- a/app/Filament/Resources/TbLaunchResource/Pages/ListTbLaunches.php
+++ b/app/Filament/Resources/TbLaunchResource/Pages/ListTbLaunches.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Filament\Resources\TbLaunchResource\Pages;
+
+use App\Filament\Resources\TbLaunchResource;
+use App\Filament\Support\ResolvesFilialConnection;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTbLaunches extends ListRecords
+{
+    protected static string $resource = TbLaunchResource::class;
+
+    public function mount(): void
+    {
+        ResolvesFilialConnection::assertConnected();
+
+        parent::mount();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/TbOperationResource.php
+++ b/app/Filament/Resources/TbOperationResource.php
@@ -5,12 +5,16 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\TbOperationResource\Pages;
 use App\Filament\Resources\TbOperationResource\RelationManagers;
 use App\Entities\TbOperation;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbOperationRepository;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class TbOperationResource extends Resource
@@ -81,7 +85,10 @@ class TbOperationResource extends Resource
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->before(function (Collection $records) {
+                            $records->each(fn (Model $record) => LookupReplication::beforeDelete($record, TbOperationRepository::class));
+                        }),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/TbOperationResource/Pages/CreateTbOperation.php
+++ b/app/Filament/Resources/TbOperationResource/Pages/CreateTbOperation.php
@@ -3,10 +3,22 @@
 namespace App\Filament\Resources\TbOperationResource\Pages;
 
 use App\Filament\Resources\TbOperationResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbOperationRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateTbOperation extends CreateRecord
 {
     protected static string $resource = TbOperationResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $record = static::getModel()::create($data);
+
+        LookupReplication::afterCreate($record, $data, TbOperationRepository::class);
+
+        return $record;
+    }
 }

--- a/app/Filament/Resources/TbOperationResource/Pages/EditTbOperation.php
+++ b/app/Filament/Resources/TbOperationResource/Pages/EditTbOperation.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Resources\TbOperationResource\Pages;
 
 use App\Filament\Resources\TbOperationResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbOperationRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditTbOperation extends EditRecord
 {
@@ -13,7 +16,17 @@ class EditTbOperation extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\DeleteAction::make(),
+            Actions\DeleteAction::make()
+                ->before(fn (Model $record) => LookupReplication::beforeDelete($record, TbOperationRepository::class)),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $record->update($data);
+
+        LookupReplication::afterUpdate($record, $data, TbOperationRepository::class);
+
+        return $record;
     }
 }

--- a/app/Filament/Resources/TbPaymentTypeResource.php
+++ b/app/Filament/Resources/TbPaymentTypeResource.php
@@ -5,12 +5,16 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\TbPaymentTypeResource\Pages;
 use App\Filament\Resources\TbPaymentTypeResource\RelationManagers;
 use App\Entities\TbPaymentType;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbPaymentTypeRepository;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class TbPaymentTypeResource extends Resource
@@ -81,7 +85,10 @@ class TbPaymentTypeResource extends Resource
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->before(function (Collection $records) {
+                            $records->each(fn (Model $record) => LookupReplication::beforeDelete($record, TbPaymentTypeRepository::class));
+                        }),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/TbPaymentTypeResource/Pages/CreateTbPaymentType.php
+++ b/app/Filament/Resources/TbPaymentTypeResource/Pages/CreateTbPaymentType.php
@@ -3,10 +3,22 @@
 namespace App\Filament\Resources\TbPaymentTypeResource\Pages;
 
 use App\Filament\Resources\TbPaymentTypeResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbPaymentTypeRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateTbPaymentType extends CreateRecord
 {
     protected static string $resource = TbPaymentTypeResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $record = static::getModel()::create($data);
+
+        LookupReplication::afterCreate($record, $data, TbPaymentTypeRepository::class);
+
+        return $record;
+    }
 }

--- a/app/Filament/Resources/TbPaymentTypeResource/Pages/EditTbPaymentType.php
+++ b/app/Filament/Resources/TbPaymentTypeResource/Pages/EditTbPaymentType.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Resources\TbPaymentTypeResource\Pages;
 
 use App\Filament\Resources\TbPaymentTypeResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbPaymentTypeRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditTbPaymentType extends EditRecord
 {
@@ -13,7 +16,17 @@ class EditTbPaymentType extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\DeleteAction::make(),
+            Actions\DeleteAction::make()
+                ->before(fn (Model $record) => LookupReplication::beforeDelete($record, TbPaymentTypeRepository::class)),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $record->update($data);
+
+        LookupReplication::afterUpdate($record, $data, TbPaymentTypeRepository::class);
+
+        return $record;
     }
 }

--- a/app/Filament/Resources/TbTypeLaunchResource.php
+++ b/app/Filament/Resources/TbTypeLaunchResource.php
@@ -5,12 +5,16 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\TbTypeLaunchResource\Pages;
 use App\Filament\Resources\TbTypeLaunchResource\RelationManagers;
 use App\Entities\TbTypeLaunch;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbTypeLaunchRepository;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class TbTypeLaunchResource extends Resource
@@ -81,7 +85,10 @@ class TbTypeLaunchResource extends Resource
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->before(function (Collection $records) {
+                            $records->each(fn (Model $record) => LookupReplication::beforeDelete($record, TbTypeLaunchRepository::class));
+                        }),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/TbTypeLaunchResource/Pages/CreateTbTypeLaunch.php
+++ b/app/Filament/Resources/TbTypeLaunchResource/Pages/CreateTbTypeLaunch.php
@@ -3,10 +3,22 @@
 namespace App\Filament\Resources\TbTypeLaunchResource\Pages;
 
 use App\Filament\Resources\TbTypeLaunchResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbTypeLaunchRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateTbTypeLaunch extends CreateRecord
 {
     protected static string $resource = TbTypeLaunchResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $record = static::getModel()::create($data);
+
+        LookupReplication::afterCreate($record, $data, TbTypeLaunchRepository::class);
+
+        return $record;
+    }
 }

--- a/app/Filament/Resources/TbTypeLaunchResource/Pages/EditTbTypeLaunch.php
+++ b/app/Filament/Resources/TbTypeLaunchResource/Pages/EditTbTypeLaunch.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Resources\TbTypeLaunchResource\Pages;
 
 use App\Filament\Resources\TbTypeLaunchResource;
+use App\Filament\Support\LookupReplication;
+use App\Repositories\TbTypeLaunchRepository;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class EditTbTypeLaunch extends EditRecord
 {
@@ -13,7 +16,17 @@ class EditTbTypeLaunch extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\DeleteAction::make(),
+            Actions\DeleteAction::make()
+                ->before(fn (Model $record) => LookupReplication::beforeDelete($record, TbTypeLaunchRepository::class)),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $record->update($data);
+
+        LookupReplication::afterUpdate($record, $data, TbTypeLaunchRepository::class);
+
+        return $record;
     }
 }

--- a/app/Filament/Support/LookupReplication.php
+++ b/app/Filament/Support/LookupReplication.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Filament\Support;
+
+use App\Services\ReplicaDbService;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Replicação matriz→filiais para os Resources "lookup" do Filament
+ * (TbPaymentType, TbCaixa, TbTypeLaunch, TbBase, TbOperation): gravam
+ * primeiro na matriz (comportamento padrão do painel) e, depois, replicam
+ * a mudança pra todas as filiais via App\Services\ReplicaDbService,
+ * rastreando o registro correspondente em cada filial pela coluna id_mtz
+ * (não pela chave primária local, que é um autoincremento independente
+ * por banco).
+ */
+class LookupReplication
+{
+    public static function afterCreate(Model $record, array $data, string $repositoryClass): void
+    {
+        app(ReplicaDbService::class)->createWithMtzTracking($data, app($repositoryClass), $record->id);
+    }
+
+    public static function afterUpdate(Model $record, array $data, string $repositoryClass): void
+    {
+        app(ReplicaDbService::class)->updateWithMtzTracking($data, $record->id, app($repositoryClass));
+    }
+
+    public static function beforeDelete(Model $record, string $repositoryClass): void
+    {
+        app(ReplicaDbService::class)->deleteWithMtzTracking($record->id, app($repositoryClass));
+    }
+}

--- a/app/Filament/Support/ResolvesFilialConnection.php
+++ b/app/Filament/Support/ResolvesFilialConnection.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Filament\Support;
+
+use App\Entities\TbBase;
+use App\Http\Controllers\ConnectDbController;
+use Filament\Notifications\Notification;
+use Filament\Support\Exceptions\Halt;
+use Illuminate\Support\Collection;
+
+/**
+ * Troca de conexão de banco por filial dentro do painel Filament.
+ *
+ * As rotas do Filament não passam por routes/web.php, então os middlewares
+ * de troca de base do sistema legado (reconnect, accesses_filial) não se
+ * aplicam aqui. Além disso, o middleware do próprio painel não é suficiente
+ * sozinho: ações do Livewire (criar, salvar, etc.) rodam como requisições
+ * PHP novas que não necessariamente re-executam o middleware da forma
+ * esperada. Por isso a conexão precisa ser reafirmada explicitamente aqui,
+ * a cada chamada que efetivamente toca o banco (mount, getEloquentQuery,
+ * handleRecordCreation, handleRecordUpdate, etc.) — mesmo padrão defensivo
+ * que App\Services\TbLaunchService já usa hoje.
+ *
+ * Usa uma chave de sessão própria do painel ('filament.base'), separada de
+ * session('base') do sistema legado, para não acoplar os dois: trocar a
+ * filial aqui não deve mudar silenciosamente o comportamento do sistema
+ * antigo numa aba diferente do mesmo navegador.
+ */
+class ResolvesFilialConnection
+{
+    public static function currentBase(): ?array
+    {
+        return session('filament.base');
+    }
+
+    public static function setCurrentBase(TbBase $base): void
+    {
+        session(['filament.base' => [
+            'id' => $base->id,
+            'sigla' => $base->sigla,
+            'name' => $base->name,
+        ]]);
+    }
+
+    public static function clearCurrentBase(): void
+    {
+        session()->forget('filament.base');
+    }
+
+    /**
+     * Garante que a conexão do banco está na filial selecionada na sessão.
+     * Se nenhuma filial foi selecionada ainda, notifica e interrompe a
+     * execução (Halt) — o middleware EnsureFilialSelected cuida de
+     * redirecionar antes de chegar aqui na maioria dos casos, isso é
+     * só a garantia de última linha.
+     */
+    public static function assertConnected(): void
+    {
+        $base = static::currentBase();
+
+        if (! $base) {
+            Notification::make()
+                ->title('Selecione uma filial')
+                ->body('Escolha uma filial antes de continuar.')
+                ->warning()
+                ->send();
+
+            throw new Halt();
+        }
+
+        app(ConnectDbController::class)->connectBases($base['sigla']);
+    }
+
+    /**
+     * Filiais que o usuário autenticado pode selecionar. Administradores
+     * (role Admin) veem todas; os demais só as atribuídas via
+     * TbCadUser::bases() (tabela user_has_base). Sempre resolvido contra a
+     * matriz, já que TbBase e user_has_base são geridos só lá.
+     */
+    public static function availableBasesFor($user): Collection
+    {
+        app(ConnectDbController::class)->connectMatriz();
+
+        if ($user->hasRole('Admin')) {
+            return TbBase::query()->orderBy('name')->get();
+        }
+
+        return $user->bases()->orderBy('name')->get();
+    }
+}

--- a/app/Filament/Support/ResolvesFilialConnection.php
+++ b/app/Filament/Support/ResolvesFilialConnection.php
@@ -87,4 +87,41 @@ class ResolvesFilialConnection
 
         return $user->bases()->orderBy('name')->get();
     }
+
+    /**
+     * App\Services\TbLaunchService::store() termina revertendo a conexão pra
+     * filial através de ConnectDbController::connectBase(), que lê
+     * session('base') — a chave do sistema legado, não a nossa
+     * ('filament.base'). Numa sessão que só passou pelo painel Filament essa
+     * chave nunca existe, então connectBase() vira um no-op e o passo do
+     * store() que atualiza id_mtz na filial acaba rodando na conexão errada
+     * (matriz), correndo o risco de sobrescrever um registro de outra
+     * filial/matriz que por acaso tenha o mesmo id.
+     *
+     * Em vez de reimplementar TbLaunchService (mantido intocado de propósito
+     * — já testado em produção), preenchemos session('base') no formato que
+     * ConnectDbController espera só durante a chamada, e desfazemos logo
+     * depois — a sessão é persistida no fim do request, então nada disso
+     * escapa pra uma aba aberta no sistema legado.
+     */
+    public static function withLegacyBaseSessionBridge(callable $callback): mixed
+    {
+        $base = static::currentBase();
+        $hadPrevious = session()->has('base');
+        $previous = session('base');
+
+        session(['base' => [['sigla' => $base['sigla']]]]);
+
+        try {
+            return $callback();
+        } finally {
+            if ($hadPrevious) {
+                session(['base' => $previous]);
+            } else {
+                session()->forget('base');
+            }
+
+            static::assertConnected();
+        }
+    }
 }

--- a/app/Http/Middleware/Filament/EnsureFilialSelected.php
+++ b/app/Http/Middleware/Filament/EnsureFilialSelected.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware\Filament;
+
+use App\Filament\Pages\SelectFilial;
+use App\Filament\Support\ResolvesFilialConnection;
+use Closure;
+use Illuminate\Http\Request;
+
+/**
+ * Camada de UX: redireciona para a seleção de filial antes de entrar numa
+ * tela que depende dela (hoje só TbLaunchResource). Não é a garantia de
+ * correção — essa continua sendo ResolvesFilialConnection::assertConnected()
+ * chamado explicitamente dentro dos hooks que tocam o banco (ver
+ * app/Filament/Support/ResolvesFilialConnection.php).
+ */
+class EnsureFilialSelected
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (
+            $request->routeIs('filament.admin.resources.tb-launches.*')
+            && ! ResolvesFilialConnection::currentBase()
+        ) {
+            return redirect(SelectFilial::getUrl());
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -53,12 +53,20 @@ class AdminPanelProvider extends PanelProvider
                 DispatchServingFilamentEvent::class,
                 // As rotas do Filament não passam por routes/web.php, então os
                 // middlewares de troca de base (reconnect, accesses_filial) não se
-                // aplicam aqui automaticamente. As entidades geridas neste painel
-                // hoje só existem na base matriz, então basta forçar a conexão
-                // matriz a cada request. Uma tela por filial (Caixa/Lançamentos)
-                // vai exigir um seletor de base dentro do próprio painel.
+                // aplicam aqui automaticamente. Os Resources de configuração
+                // (TbPaymentType, TbCaixa, TbOperation, TbTypeLaunch, TbBase,
+                // Roles, Permissions) são geridos só contra a matriz, então basta
+                // forçar essa conexão a cada request. TbLaunchResource é por
+                // filial — usa o seletor de base próprio do painel
+                // (App\Filament\Pages\SelectFilial) e reafirma a conexão
+                // explicitamente em cada hook que toca o banco (ver
+                // App\Filament\Support\ResolvesFilialConnection), já que nem
+                // middleware persistente garante reexecução nas ações do Livewire.
                 \App\Http\Middleware\ReconnectDbDefault::class,
             ])
+            ->middleware([
+                \App\Http\Middleware\Filament\EnsureFilialSelected::class,
+            ], isPersistent: true)
             ->authMiddleware([
                 Authenticate::class,
             ]);

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -33,6 +33,7 @@ class RepositoryServiceProvider extends ServiceProvider
         $this->app->bind(\App\Repositories\TbClosingRepository::class, \App\Repositories\TbClosingRepositoryEloquent::class);
         $this->app->bind(\App\Repositories\PaymentTypeRepository::class, \App\Repositories\PaymentTypeRepositoryEloquent::class);
         $this->app->bind(\App\Repositories\TbPaymentTypeRepository::class, \App\Repositories\TbPaymentTypeRepositoryEloquent::class);
+        $this->app->bind(\App\Repositories\TbOperationRepository::class, \App\Repositories\TbOperationRepositoryEloquent::class);
         //:end-bindings:
     }
 }

--- a/app/Repositories/TbOperationRepository.php
+++ b/app/Repositories/TbOperationRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repositories;
+
+use Prettus\Repository\Contracts\RepositoryInterface;
+
+/**
+ * Interface TbOperationRepository.
+ *
+ * @package namespace App\Repositories;
+ */
+interface TbOperationRepository extends RepositoryInterface
+{
+    //
+}

--- a/app/Repositories/TbOperationRepositoryEloquent.php
+++ b/app/Repositories/TbOperationRepositoryEloquent.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repositories;
+
+use Prettus\Repository\Eloquent\BaseRepository;
+use Prettus\Repository\Criteria\RequestCriteria;
+use App\Repositories\TbOperationRepository;
+use App\Entities\TbOperation;
+use App\Validators\TbOperationValidator;
+
+/**
+ * Class TbOperationRepositoryEloquent.
+ *
+ * @package namespace App\Repositories;
+ */
+class TbOperationRepositoryEloquent extends BaseRepository implements TbOperationRepository
+{
+    public function selectBoxList(string $descrição = 'name', string $chave = 'id')
+    {
+        return $this->model->pluck($descrição, $chave);
+    }
+
+    /**
+     * Specify Model class name
+     *
+     * @return string
+     */
+    public function model()
+    {
+        return TbOperation::class;
+    }
+
+    /**
+    * Specify Validator class name
+    *
+    * @return mixed
+    */
+    public function validator()
+    {
+        return TbOperationValidator::class;
+    }
+
+    /**
+     * Boot up the repository, pushing criteria
+     */
+    public function boot()
+    {
+        $this->pushCriteria(app(RequestCriteria::class));
+    }
+}

--- a/app/Services/ReplicaDbService.php
+++ b/app/Services/ReplicaDbService.php
@@ -88,6 +88,66 @@ class ReplicaDbService
 
     /*
     |--------------------------------------------------------------------------
+    | Replicadores com rastreamento por id_mtz (TbPaymentType, TbCaixa,
+    | TbTypeLaunch, TbBase, TbOperation — Resources "lookup" do Filament)
+    |--------------------------------------------------------------------------
+    |
+    | Diferente dos replicadores genéricos acima (create/update/delete), que
+    | resolvem o registro na filial pela própria chave primária — o que só
+    | funciona quando os autoincrementos de matriz e filial andam em
+    | lockstep — estes usam a coluna id_mtz pra localizar o registro
+    | correspondente na filial de forma confiável, já que cada banco tem
+    | autoincremento independente.
+    */
+
+    public function createWithMtzTracking(array $data, $repository, int $mtzId): void
+    {
+        activity()->disableLogging();
+        foreach ($this->bases as $base) {
+            $base = $base['sigla'];
+            if ($base != 'adb_mtz') {
+                $this->ConnectDbController->connectBases($base);
+                $repository->create(array_merge($data, ['id_mtz' => $mtzId]));
+            }
+        }
+        activity()->enableLogging();
+    }
+
+    public function updateWithMtzTracking(array $data, int $mtzId, $repository): void
+    {
+        activity()->disableLogging();
+        foreach ($this->bases as $base) {
+            $base = $base['sigla'];
+            if ($base != 'adb_mtz') {
+                $this->ConnectDbController->connectBases($base);
+                $record = $repository->findWhere(['id_mtz' => $mtzId])->first();
+                if ($record) {
+                    $repository->update($data, $record->id);
+                }
+            }
+        }
+        activity()->enableLogging();
+    }
+
+    public function deleteWithMtzTracking(int $mtzId, $repository): void
+    {
+        activity()->disableLogging();
+        foreach ($this->bases as $base) {
+            $base = $base['sigla'];
+            if ($base != 'adb_mtz') {
+                $this->ConnectDbController->connectBases($base);
+                $record = $repository->findWhere(['id_mtz' => $mtzId])->first();
+                if ($record) {
+                    $repository->delete($record->id);
+                }
+            }
+        }
+        activity()->enableLogging();
+    }
+
+
+    /*
+    |--------------------------------------------------------------------------
     | Replicadores para a classe roles
     |--------------------------------------------------------------------------
     */

--- a/app/Validators/TbOperationValidator.php
+++ b/app/Validators/TbOperationValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Validators;
+
+use \Prettus\Validator\Contracts\ValidatorInterface;
+use \Prettus\Validator\LaravelValidator;
+
+/**
+ * Class TbOperationValidator.
+ *
+ * @package namespace App\Validators;
+ */
+class TbOperationValidator extends LaravelValidator
+{
+    /**
+     * Validation Rules
+     *
+     * @var array
+     */
+    protected $rules = [
+        ValidatorInterface::RULE_CREATE => [],
+        ValidatorInterface::RULE_UPDATE => [],
+    ];
+}

--- a/database/migrations/2026_08_27_183306_create_user_has_base_table.php
+++ b/database/migrations/2026_08_27_183306_create_user_has_base_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUserHasBaseTable extends Migration
+{
+    /**
+     * Schema table name to migrate
+     * @var string
+     */
+    public $tableName = 'user_has_base';
+
+    /**
+     * Run the migrations.
+     * @table user_has_base
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->tableName, function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('idtb_base');
+
+            $table->index(["user_id"], 'fk_tb_cad_user_has_tb_base_tb_cad_user1_idx');
+
+            $table->index(["idtb_base"], 'fk_tb_cad_user_has_tb_base_tb_base1_idx');
+            $table->softDeletes();
+            $table->nullableTimestamps();
+
+
+            $table->foreign('user_id', 'fk_tb_cad_user_has_tb_base_tb_cad_user1_idx')
+                ->references('id')->on('tb_cad_user')
+                ->onDelete('no action')
+                ->onUpdate('no action');
+
+            $table->foreign('idtb_base', 'fk_tb_cad_user_has_tb_base_tb_base1_idx')
+                ->references('id')->on('tb_base')
+                ->onDelete('no action')
+                ->onUpdate('no action');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists($this->tableName);
+    }
+}

--- a/database/migrations/2026_08_27_183400_add_id_mtz_to_tb_payment_type_table.php
+++ b/database/migrations/2026_08_27_183400_add_id_mtz_to_tb_payment_type_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIdMtzToTbPaymentTypeTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('tb_payment_type', function (Blueprint $table) {
+            $table->unsignedInteger('id_mtz')->nullable()->after('id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('tb_payment_type', function (Blueprint $table) {
+            $table->dropColumn('id_mtz');
+        });
+    }
+}

--- a/database/migrations/2026_08_27_183401_add_id_mtz_to_tb_caixa_table.php
+++ b/database/migrations/2026_08_27_183401_add_id_mtz_to_tb_caixa_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIdMtzToTbCaixaTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('tb_caixa', function (Blueprint $table) {
+            $table->unsignedInteger('id_mtz')->nullable()->after('id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('tb_caixa', function (Blueprint $table) {
+            $table->dropColumn('id_mtz');
+        });
+    }
+}

--- a/database/migrations/2026_08_27_183402_add_id_mtz_to_tb_type_launch_table.php
+++ b/database/migrations/2026_08_27_183402_add_id_mtz_to_tb_type_launch_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIdMtzToTbTypeLaunchTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('tb_type_launch', function (Blueprint $table) {
+            $table->unsignedInteger('id_mtz')->nullable()->after('id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('tb_type_launch', function (Blueprint $table) {
+            $table->dropColumn('id_mtz');
+        });
+    }
+}

--- a/database/migrations/2026_08_27_183403_add_id_mtz_to_tb_base_table.php
+++ b/database/migrations/2026_08_27_183403_add_id_mtz_to_tb_base_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIdMtzToTbBaseTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('tb_base', function (Blueprint $table) {
+            $table->unsignedInteger('id_mtz')->nullable()->after('id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('tb_base', function (Blueprint $table) {
+            $table->dropColumn('id_mtz');
+        });
+    }
+}

--- a/database/migrations/2026_08_27_183404_add_id_mtz_to_tb_operation_table.php
+++ b/database/migrations/2026_08_27_183404_add_id_mtz_to_tb_operation_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIdMtzToTbOperationTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('tb_operation', function (Blueprint $table) {
+            $table->unsignedInteger('id_mtz')->nullable()->after('id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('tb_operation', function (Blueprint $table) {
+            $table->dropColumn('id_mtz');
+        });
+    }
+}

--- a/resources/views/filament/pages/select-filial.blade.php
+++ b/resources/views/filament/pages/select-filial.blade.php
@@ -1,0 +1,13 @@
+<x-filament-panels::page>
+    <form wire:submit="submit">
+        {{ $this->form }}
+
+        <x-filament-panels::form.actions
+            :actions="[
+                \Filament\Actions\Action::make('submit')
+                    ->label('Selecionar')
+                    ->submit('submit'),
+            ]"
+        />
+    </form>
+</x-filament-panels::page>

--- a/tests/Feature/LookupReplicationTest.php
+++ b/tests/Feature/LookupReplicationTest.php
@@ -85,11 +85,20 @@ class LookupReplicationTest extends TestCase
     {
         Role::findOrCreate('Admin', 'web');
 
-        TbBase::query()->delete();
-        TbBase::create(['name' => 'Matriz', 'sigla' => 'adb_mtz']);
-        TbBase::create(['name' => 'Filial Vila', 'sigla' => 'adb_vla']);
-        TbBase::create(['name' => 'Filial Sede', 'sigla' => 'adb_sed']);
-        $matriz = TbBase::where('sigla', 'adb_mtz')->first();
+        // firstOrCreate (não delete+recreate) porque tests/Feature/TbLaunchResourceTest.php
+        // compartilha a mesma matriz sqlite e as mesmas siglas adb_mtz/adb_vla/adb_sed —
+        // recriar aqui trocaria os ids e quebraria o outro teste na mesma suíte.
+        $matriz = TbBase::firstOrCreate(['sigla' => 'adb_mtz'], ['name' => 'Matriz']);
+        TbBase::firstOrCreate(['sigla' => 'adb_vla'], ['name' => 'Filial Vila']);
+        TbBase::firstOrCreate(['sigla' => 'adb_sed'], ['name' => 'Filial Sede']);
+
+        // Outros testes (SelectFilialTest, FilamentSmokeTest, ...) semeiam
+        // tb_base com siglas próprias (MTZ, VLA, ...) na mesma matriz sqlite
+        // compartilhada — ReplicaDbService itera TODAS as siglas de tb_base
+        // pra replicar, então uma sigla sem conexão configurada quebraria a
+        // suíte inteira. Soft-deleta (tb_base já usa SoftDeletes) tudo que
+        // não seja uma das 3 conexões reais antes de disparar replicação.
+        TbBase::whereNotIn('sigla', ['adb_mtz', 'adb_vla', 'adb_sed'])->delete();
 
         $profile = TbProfile::firstOrCreate(['name' => 'Administrador']);
 
@@ -122,7 +131,7 @@ class LookupReplicationTest extends TestCase
             ->assertHasNoFormErrors();
 
         app(ConnectDbController::class)->connectMatriz();
-        $matrizRecord = TbPaymentType::where('name', 'Pix')->firstOrFail();
+        $matrizRecord = TbPaymentType::where('name', 'Pix')->latest('id')->firstOrFail();
 
         foreach (['adb_vla', 'adb_sed'] as $sigla) {
             app(ConnectDbController::class)->connectBases($sigla);
@@ -144,7 +153,7 @@ class LookupReplicationTest extends TestCase
             ->assertHasNoFormErrors();
 
         app(ConnectDbController::class)->connectMatriz();
-        $matrizRecord = TbPaymentType::where('name', 'Boleto')->firstOrFail();
+        $matrizRecord = TbPaymentType::where('name', 'Boleto')->latest('id')->firstOrFail();
 
         Livewire::test(EditTbPaymentType::class, ['record' => $matrizRecord->getKey()])
             ->fillForm(['name' => 'Boleto', 'descripion' => 'atualizado'])
@@ -170,7 +179,7 @@ class LookupReplicationTest extends TestCase
             ->assertHasNoFormErrors();
 
         app(ConnectDbController::class)->connectMatriz();
-        $matrizRecord = TbPaymentType::where('name', 'Cartão')->firstOrFail();
+        $matrizRecord = TbPaymentType::where('name', 'Cartão')->latest('id')->firstOrFail();
         $mtzId = $matrizRecord->id;
 
         Livewire::test(EditTbPaymentType::class, ['record' => $mtzId])
@@ -193,7 +202,7 @@ class LookupReplicationTest extends TestCase
             ->assertHasNoFormErrors();
 
         app(ConnectDbController::class)->connectMatriz();
-        $matrizRecord = TbCaixa::where('name', 'Caixa Principal')->firstOrFail();
+        $matrizRecord = TbCaixa::where('name', 'Caixa Principal')->latest('id')->firstOrFail();
         $mtzId = $matrizRecord->id;
 
         Livewire::test(EditTbCaixa::class, ['record' => $mtzId])

--- a/tests/Feature/LookupReplicationTest.php
+++ b/tests/Feature/LookupReplicationTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Entities\TbBase;
+use App\Entities\TbCadUser;
+use App\Entities\TbCaixa;
+use App\Entities\TbPaymentType;
+use App\Entities\TbProfile;
+use App\Filament\Resources\TbCaixaResource\Pages\CreateTbCaixa;
+use App\Filament\Resources\TbCaixaResource\Pages\EditTbCaixa;
+use App\Filament\Resources\TbPaymentTypeResource\Pages\CreateTbPaymentType;
+use App\Filament\Resources\TbPaymentTypeResource\Pages\EditTbPaymentType;
+use App\Http\Controllers\ConnectDbController;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Testa a replicação matriz->filiais (Fase E.0.5) dos Resources "lookup" do
+ * Filament (aqui, TbPaymentType e TbCaixa como representantes do padrão
+ * compartilhado por TbTypeLaunch/TbBase/TbOperation), rastreando o registro
+ * correspondente em cada filial pela coluna id_mtz.
+ *
+ * Usa 3 arquivos sqlite distintos (matriz, adb_vla, adb_sed) para simular de
+ * fato 3 conexões físicas separadas, já que ConnectDbController::connectBases()
+ * troca a conexão padrão do Eloquent pelo nome literal da sigla da base.
+ */
+class LookupReplicationTest extends TestCase
+{
+    private static string $vlaPath;
+    private static string $sedPath;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $base = dirname(__DIR__, 2) . '/database';
+        $mtzPath = $base . '/testing.sqlite';
+        self::$vlaPath = $base . '/testing_vla.sqlite';
+        self::$sedPath = $base . '/testing_sed.sqlite';
+
+        foreach ([$mtzPath, self::$vlaPath, self::$sedPath] as $path) {
+            if (! file_exists($path)) {
+                touch($path);
+                (new \PDO('sqlite:' . $path))->exec('PRAGMA journal_mode=WAL');
+            }
+        }
+
+        $migrate = fn (string $dbPath) => exec(
+            "DB_CONNECTION_MTZ=sqlite DB_DATABASE={$dbPath} APP_ENV=testing php artisan migrate --path=database/migrations --force 2>&1"
+        );
+
+        $migrate('database/testing.sqlite');
+        exec('DB_CONNECTION_MTZ=sqlite DB_DATABASE=database/testing.sqlite APP_ENV=testing php artisan migrate --path=database/migrations/only_bd_mtz --force 2>&1');
+        $migrate('database/testing_vla.sqlite');
+        $migrate('database/testing_sed.sqlite');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['database.connections.adb_mtz' => config('database.connections.sqlite')]);
+        config(['database.connections.adb_vla' => [
+            'driver' => 'sqlite',
+            'database' => self::$vlaPath,
+            'prefix' => '',
+        ]]);
+        config(['database.connections.adb_sed' => [
+            'driver' => 'sqlite',
+            'database' => self::$sedPath,
+            'prefix' => '',
+        ]]);
+
+        // Garante que cada teste começa e termina na conexão da matriz —
+        // o loop de replicação deixa a conexão padrão apontando pra última
+        // filial visitada.
+        app(ConnectDbController::class)->connectMatriz();
+        $this->beforeApplicationDestroyed(fn () => app(ConnectDbController::class)->connectMatriz());
+    }
+
+    private function makeAdmin(): TbCadUser
+    {
+        Role::findOrCreate('Admin', 'web');
+
+        TbBase::query()->delete();
+        TbBase::create(['name' => 'Matriz', 'sigla' => 'adb_mtz']);
+        TbBase::create(['name' => 'Filial Vila', 'sigla' => 'adb_vla']);
+        TbBase::create(['name' => 'Filial Sede', 'sigla' => 'adb_sed']);
+        $matriz = TbBase::where('sigla', 'adb_mtz')->first();
+
+        $profile = TbProfile::firstOrCreate(['name' => 'Administrador']);
+
+        $user = TbCadUser::firstOrCreate(
+            ['email' => 'lookupreplication@example.com'],
+            [
+                'name' => 'Lookup Replication Test',
+                'idtb_profile' => $profile->id,
+                'idtb_base' => $matriz->id,
+                'password' => bcrypt('secret'),
+                'status' => 1,
+            ]
+        );
+
+        if (! $user->hasRole('Admin')) {
+            $user->assignRole('Admin');
+        }
+
+        return $user;
+    }
+
+    public function test_creating_a_payment_type_replicates_to_every_filial_with_id_mtz(): void
+    {
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbPaymentType::class)
+            ->fillForm(['name' => 'Pix', 'descripion' => 'Pagamento instantâneo'])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectMatriz();
+        $matrizRecord = TbPaymentType::where('name', 'Pix')->firstOrFail();
+
+        foreach (['adb_vla', 'adb_sed'] as $sigla) {
+            app(ConnectDbController::class)->connectBases($sigla);
+            $filialRecord = TbPaymentType::where('id_mtz', $matrizRecord->id)->first();
+
+            $this->assertNotNull($filialRecord, "Registro não replicado para {$sigla}");
+            $this->assertSame('Pix', $filialRecord->name);
+        }
+    }
+
+    public function test_updating_a_payment_type_updates_every_filial_copy(): void
+    {
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbPaymentType::class)
+            ->fillForm(['name' => 'Boleto', 'descripion' => 'original'])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectMatriz();
+        $matrizRecord = TbPaymentType::where('name', 'Boleto')->firstOrFail();
+
+        Livewire::test(EditTbPaymentType::class, ['record' => $matrizRecord->getKey()])
+            ->fillForm(['name' => 'Boleto', 'descripion' => 'atualizado'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        foreach (['adb_vla', 'adb_sed'] as $sigla) {
+            app(ConnectDbController::class)->connectBases($sigla);
+            $filialRecord = TbPaymentType::where('id_mtz', $matrizRecord->id)->firstOrFail();
+
+            $this->assertSame('atualizado', $filialRecord->descripion);
+        }
+    }
+
+    public function test_deleting_a_payment_type_deletes_every_filial_copy(): void
+    {
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbPaymentType::class)
+            ->fillForm(['name' => 'Cartão', 'descripion' => 'original'])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectMatriz();
+        $matrizRecord = TbPaymentType::where('name', 'Cartão')->firstOrFail();
+        $mtzId = $matrizRecord->id;
+
+        Livewire::test(EditTbPaymentType::class, ['record' => $mtzId])
+            ->callAction('delete');
+
+        foreach (['adb_vla', 'adb_sed'] as $sigla) {
+            app(ConnectDbController::class)->connectBases($sigla);
+            $this->assertNull(TbPaymentType::where('id_mtz', $mtzId)->first(), "Registro não removido em {$sigla}");
+        }
+    }
+
+    public function test_creating_a_caixa_replicates_with_soft_delete_support(): void
+    {
+        $admin = $this->makeAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbCaixa::class)
+            ->fillForm(['name' => 'Caixa Principal', 'description' => 'teste'])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectMatriz();
+        $matrizRecord = TbCaixa::where('name', 'Caixa Principal')->firstOrFail();
+        $mtzId = $matrizRecord->id;
+
+        Livewire::test(EditTbCaixa::class, ['record' => $mtzId])
+            ->callAction('delete');
+
+        $this->assertNotNull(TbCaixa::withTrashed()->find($mtzId)->deleted_at, 'Exclusão na matriz deveria ser soft-delete');
+
+        foreach (['adb_vla', 'adb_sed'] as $sigla) {
+            app(ConnectDbController::class)->connectBases($sigla);
+            $filialRecord = TbCaixa::withTrashed()->where('id_mtz', $mtzId)->first();
+
+            $this->assertNotNull($filialRecord, "Registro não replicado para {$sigla}");
+            $this->assertNotNull($filialRecord->deleted_at, "Exclusão não replicada (soft-delete) para {$sigla}");
+        }
+    }
+}

--- a/tests/Feature/SelectFilialTest.php
+++ b/tests/Feature/SelectFilialTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Entities\TbBase;
+use App\Entities\TbCadUser;
+use App\Entities\TbProfile;
+use App\Filament\Pages\SelectFilial;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class SelectFilialTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $path = dirname(__DIR__, 2) . '/database/testing.sqlite';
+        if (! file_exists($path)) {
+            touch($path);
+            (new \PDO('sqlite:' . $path))->exec('PRAGMA journal_mode=WAL');
+        }
+
+        $env = 'DB_CONNECTION_MTZ=sqlite DB_DATABASE=database/testing.sqlite APP_ENV=testing';
+        exec("{$env} php artisan migrate --path=database/migrations --force 2>&1");
+        exec("{$env} php artisan migrate --path=database/migrations/only_bd_mtz --force 2>&1");
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['database.connections.adb_mtz' => config('database.connections.sqlite')]);
+    }
+
+    private function makeUser(string $email, ?string $role = null): TbCadUser
+    {
+        $profile = TbProfile::firstOrCreate(['name' => 'Perfil Teste']);
+        $homeBase = TbBase::firstOrCreate(['sigla' => 'MTZ'], ['name' => 'Matriz']);
+
+        $user = TbCadUser::firstOrCreate(
+            ['email' => $email],
+            [
+                'name' => $email,
+                'idtb_profile' => $profile->id,
+                'idtb_base' => $homeBase->id,
+                'password' => bcrypt('secret'),
+                'status' => 1,
+            ]
+        );
+
+        if ($role) {
+            Role::findOrCreate($role, 'web');
+            if (! $user->hasRole($role)) {
+                $user->assignRole($role);
+            }
+        }
+
+        return $user;
+    }
+
+    public function test_admin_sees_every_base_as_an_option(): void
+    {
+        $admin = $this->makeUser('admin-filial@example.com', 'Admin');
+
+        TbBase::firstOrCreate(['sigla' => 'VLA'], ['name' => 'Vila']);
+        TbBase::firstOrCreate(['sigla' => 'SED'], ['name' => 'Sede']);
+
+        Livewire::actingAs($admin)
+            ->test(SelectFilial::class)
+            ->assertFormFieldExists('idtb_base');
+
+        $options = \App\Filament\Support\ResolvesFilialConnection::availableBasesFor($admin);
+        $this->assertGreaterThanOrEqual(3, $options->count());
+    }
+
+    public function test_non_admin_only_sees_assigned_bases(): void
+    {
+        $user = $this->makeUser('launch-manager-filial@example.com', null);
+
+        $allowed = TbBase::firstOrCreate(['sigla' => 'VLA'], ['name' => 'Vila']);
+        TbBase::firstOrCreate(['sigla' => 'SED'], ['name' => 'Sede']);
+
+        $user->bases()->syncWithoutDetaching([$allowed->id]);
+
+        $options = \App\Filament\Support\ResolvesFilialConnection::availableBasesFor($user->fresh());
+
+        $this->assertCount(1, $options);
+        $this->assertSame($allowed->id, $options->first()->id);
+    }
+
+    public function test_selecting_an_unauthorized_base_is_rejected(): void
+    {
+        $user = $this->makeUser('launch-manager-filial2@example.com', null);
+
+        $allowed = TbBase::firstOrCreate(['sigla' => 'VLA2'], ['name' => 'Vila 2']);
+        $forbidden = TbBase::firstOrCreate(['sigla' => 'SED2'], ['name' => 'Sede 2']);
+
+        $user->bases()->syncWithoutDetaching([$allowed->id]);
+
+        Livewire::actingAs($user->fresh())
+            ->test(SelectFilial::class)
+            ->fillForm(['idtb_base' => $forbidden->id])
+            ->call('submit');
+
+        $this->assertNull(session('filament.base'));
+    }
+}

--- a/tests/Feature/TbLaunchResourceTest.php
+++ b/tests/Feature/TbLaunchResourceTest.php
@@ -1,0 +1,354 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Entities\TbBase;
+use App\Entities\TbCadUser;
+use App\Entities\TbCaixa;
+use App\Entities\TbClosing;
+use App\Entities\TbLaunch;
+use App\Entities\TbOperation;
+use App\Entities\TbPaymentType;
+use App\Entities\TbProfile;
+use App\Entities\TbTypeLaunch;
+use App\Filament\Resources\TbLaunchResource\Pages\CreateTbLaunch;
+use App\Filament\Resources\TbLaunchResource\Pages\EditTbLaunch;
+use App\Filament\Support\ResolvesFilialConnection;
+use App\Http\Controllers\ConnectDbController;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Testa o TbLaunchResource unificado (Fase E.2): criação/edição/exclusão
+ * delegando pra App\Services\TbLaunchService (bloqueio de período fechado
+ * incluso), replicação matriz<->filial via id_filial/id_mtz, e a ação de
+ * aprovar/reprovar checando a permission launch-approves contra a matriz.
+ *
+ * Mesma ideia de 3 sqlite físicos (matriz + adb_vla + adb_sed) de
+ * tests/Feature/LookupReplicationTest.php pra simular duas conexões de
+ * filial distintas, mas com arquivos de filial próprios (ver
+ * setUpBeforeClass) já que aqui os ids de tb_caixa/tb_operation/etc são
+ * fixos.
+ */
+class TbLaunchResourceTest extends TestCase
+{
+    private static string $vlaPath;
+    private static string $sedPath;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $base = dirname(__DIR__, 2) . '/database';
+        $mtzPath = $base . '/testing.sqlite';
+        // Arquivos próprios (não os de LookupReplicationTest) porque este
+        // teste semeia tb_caixa/tb_operation/tb_type_launch/tb_payment_type
+        // com ids fixos na filial — compartilhar o arquivo com outro teste
+        // que cria registros com auto-increment correria risco de colisão
+        // de id na mesma suíte.
+        self::$vlaPath = $base . '/testing_launch_vla.sqlite';
+        self::$sedPath = $base . '/testing_launch_sed.sqlite';
+
+        foreach ([$mtzPath, self::$vlaPath, self::$sedPath] as $path) {
+            if (! file_exists($path)) {
+                touch($path);
+                (new \PDO('sqlite:' . $path))->exec('PRAGMA journal_mode=WAL');
+            }
+        }
+
+        $migrate = fn (string $dbPath) => exec(
+            "DB_CONNECTION_MTZ=sqlite DB_DATABASE={$dbPath} APP_ENV=testing php artisan migrate --path=database/migrations --force 2>&1"
+        );
+
+        $migrate('database/testing.sqlite');
+        exec('DB_CONNECTION_MTZ=sqlite DB_DATABASE=database/testing.sqlite APP_ENV=testing php artisan migrate --path=database/migrations/only_bd_mtz --force 2>&1');
+        $migrate(self::$vlaPath);
+        $migrate(self::$sedPath);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['database.connections.adb_mtz' => config('database.connections.sqlite')]);
+        config(['database.connections.adb_vla' => [
+            'driver' => 'sqlite',
+            'database' => self::$vlaPath,
+            'prefix' => '',
+        ]]);
+        config(['database.connections.adb_sed' => [
+            'driver' => 'sqlite',
+            'database' => self::$sedPath,
+            'prefix' => '',
+        ]]);
+
+        app(ConnectDbController::class)->connectMatriz();
+        $this->beforeApplicationDestroyed(fn () => app(ConnectDbController::class)->connectMatriz());
+    }
+
+    /**
+     * Semeia matriz + filial 'adb_vla' com os cadastros necessários pro
+     * lançamento (caixa, operação, tipo de lançamento, tipo de pagamento e
+     * fechamento) diretamente em cada conexão — sem passar pela replicação
+     * da Fase E.0.5, que já tem cobertura própria em LookupReplicationTest.
+     */
+    private function seedFilial(): TbBase
+    {
+        Role::findOrCreate('Admin', 'web');
+
+        // firstOrCreate (não delete+recreate) porque tests/Feature/LookupReplicationTest.php
+        // compartilha a mesma matriz sqlite e as mesmas siglas adb_mtz/adb_vla/adb_sed.
+        TbBase::firstOrCreate(['sigla' => 'adb_mtz'], ['name' => 'Matriz']);
+        $vla = TbBase::firstOrCreate(['sigla' => 'adb_vla'], ['name' => 'Filial Vila']);
+        TbBase::firstOrCreate(['sigla' => 'adb_sed'], ['name' => 'Filial Sede']);
+
+        // Ver comentário equivalente em LookupReplicationTest::makeAdmin().
+        TbBase::whereNotIn('sigla', ['adb_mtz', 'adb_vla', 'adb_sed'])->delete();
+
+        TbLaunch::withTrashed()->forceDelete();
+
+        $profile = TbProfile::firstOrCreate(['name' => 'Administrador']);
+        $matriz = TbBase::where('sigla', 'adb_mtz')->first();
+
+        $admin = TbCadUser::firstOrCreate(
+            ['email' => 'launch-admin@example.com'],
+            [
+                'name' => 'Launch Admin',
+                'idtb_profile' => $profile->id,
+                'idtb_base' => $matriz->id,
+                'password' => bcrypt('secret'),
+                'status' => 1,
+            ]
+        );
+        if (! $admin->hasRole('Admin')) {
+            $admin->assignRole('Admin');
+        }
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+
+        TbCadUser::firstOrCreate(
+            ['email' => 'launch-admin@example.com'],
+            [
+                'name' => 'Launch Admin',
+                'idtb_profile' => $profile->id,
+                'idtb_base' => $matriz->id,
+                'password' => bcrypt('secret'),
+                'status' => 1,
+                'id' => $admin->id,
+            ]
+        );
+
+        TbLaunch::withTrashed()->forceDelete();
+        TbClosing::withTrashed()->forceDelete();
+        TbCaixa::withTrashed()->forceDelete();
+        TbOperation::query()->delete();
+        TbTypeLaunch::query()->delete();
+        TbPaymentType::query()->delete();
+
+        TbCaixa::create(['id' => 1, 'name' => 'Caixa Principal']);
+        TbOperation::create(['id' => 1, 'name' => 'Entrada']);
+        TbOperation::create(['id' => 2, 'name' => 'Saída']);
+        TbTypeLaunch::create(['id' => 1, 'name' => 'Dízimo']);
+        TbPaymentType::create(['id' => 1, 'name' => 'Dinheiro']);
+        TbClosing::create(['id' => 1, 'month' => 'Agosto', 'year' => 2026, 'status' => 1, 'period_valid' => 0]);
+
+        app(ConnectDbController::class)->connectMatriz();
+
+        ResolvesFilialConnection::setCurrentBase($vla);
+
+        return $vla;
+    }
+
+    private function actingAsAdmin(): TbCadUser
+    {
+        return TbCadUser::where('email', 'launch-admin@example.com')->firstOrFail();
+    }
+
+    public function test_creating_a_launch_replicates_a_mirror_to_the_matriz(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 150.5,
+                'description' => 'Oferta especial',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $filialLaunch = TbLaunch::where('description', 'Oferta especial')->firstOrFail();
+        $this->assertSame(0, (int) $filialLaunch->status);
+        $this->assertNotNull($filialLaunch->id_mtz);
+
+        app(ConnectDbController::class)->connectMatriz();
+        $matrizLaunch = TbLaunch::where('id', $filialLaunch->id_mtz)->first();
+        $this->assertNotNull($matrizLaunch, 'Lançamento não espelhado na matriz');
+        $this->assertEquals($filialLaunch->id, $matrizLaunch->id_filial);
+        $this->assertSame('Oferta especial', $matrizLaunch->description);
+    }
+
+    public function test_creating_a_launch_in_a_closed_period_is_blocked(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        TbClosing::where('id', 1)->update(['status' => 0]);
+        app(ConnectDbController::class)->connectMatriz();
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 10,
+            ])
+            ->call('create');
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $this->assertSame(0, TbLaunch::count());
+    }
+
+    public function test_updating_a_launch_updates_the_matriz_mirror(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 100,
+                'description' => 'original',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $filialLaunch = TbLaunch::where('description', 'original')->firstOrFail();
+        $idMtz = $filialLaunch->id_mtz;
+        app(ConnectDbController::class)->connectMatriz();
+
+        Livewire::test(EditTbLaunch::class, ['record' => $filialLaunch->getKey()])
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 200,
+                'description' => 'atualizado',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $this->assertSame('atualizado', TbLaunch::find($filialLaunch->id)->description);
+
+        app(ConnectDbController::class)->connectMatriz();
+        $this->assertSame('atualizado', TbLaunch::find($idMtz)->description);
+    }
+
+    public function test_approving_a_launch_via_the_service_mirrors_the_status_to_the_matriz(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 50,
+                'description' => 'a aprovar',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $filialLaunch = TbLaunch::where('description', 'a aprovar')->firstOrFail();
+        $idMtz = $filialLaunch->id_mtz;
+
+        // aprov_id(), assim como store()/update(), espera ser chamado com a
+        // conexão já na filial — quem reverte pra matriz é o próprio método.
+        $result = app(\App\Services\TbLaunchService::class)->aprov_id([
+            'id' => $filialLaunch->id,
+            'status' => 1,
+        ]);
+
+        $this->assertTrue($result['success']);
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $this->assertSame(1, (int) TbLaunch::find($filialLaunch->id)->status);
+
+        app(ConnectDbController::class)->connectMatriz();
+        $this->assertSame(1, (int) TbLaunch::find($idMtz)->status);
+    }
+
+    public function test_approve_action_is_gated_by_launch_approves_permission_checked_on_matriz(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        // Sqlite de teste acumula entre execuções — garante que o admin
+        // começa sem a permission antes de checar o caso "sem permissão".
+        Permission::findOrCreate('launch-approves', 'web');
+        if ($admin->hasPermissionTo('launch-approves')) {
+            $admin->revokePermissionTo('launch-approves');
+        }
+
+        $userCanApprove = new \ReflectionMethod(\App\Filament\Resources\TbLaunchResource::class, 'userCanApprove');
+        $userCanApprove->setAccessible(true);
+        $cache = new \ReflectionProperty(\App\Filament\Resources\TbLaunchResource::class, 'canApproveCache');
+        $cache->setAccessible(true);
+
+        $cache->setValue(null, null);
+        $this->assertFalse($userCanApprove->invoke(null));
+
+        // userCanApprove() deixa a conexão de volta na filial ao terminar —
+        // a permission precisa ser criada/concedida na matriz, então força
+        // a conexão antes de mexer em Role/Permission.
+        app(ConnectDbController::class)->connectMatriz();
+        Permission::findOrCreate('launch-approves', 'web');
+        $admin->givePermissionTo('launch-approves');
+
+        $cache->setValue(null, null);
+        $this->assertTrue($userCanApprove->invoke(null));
+
+        // A checagem roda contra a matriz por dentro, mas precisa devolver
+        // a conexão pra filial ativa da sessão ao terminar.
+        $this->assertSame(self::$vlaPath, DB::connection()->getConfig('database'));
+    }
+}


### PR DESCRIPTION
## Summary

Expande o painel Filament (adicionado nas PRs #135-#139) para as duas telas mais sensíveis que ainda faltavam: seleção de filial e Lançamentos (Entrada/Saída), num sistema onde cada filial é uma **conexão física de banco separada** (`adb_mtz`/`adb_vla`/`adb_sed`).

**Fase E.0 — Infraestrutura de seleção de base + restrição por usuário**
- Nova tabela `user_has_base` (mesmo padrão de `user_has_closing`/`user_has_launch`) + `TbCadUser::bases()`.
- `App\Filament\Support\ResolvesFilialConnection`: sessão própria do painel (`filament.base`, separada de `session('base')` do sistema legado, para não acoplar as duas UIs), `assertConnected()` reafirma a conexão a cada operação que toca o banco (as ações do Livewire rodam como requisições PHP separadas, então o middleware sozinho não é suficiente).
- `App\Filament\Pages\SelectFilial`: Admin vê todas as bases; os demais usuários só as atribuídas via `user_has_base`. A filial pode ser trocada livremente a qualquer momento durante a sessão do painel.
- `EnsureFilialSelected` middleware redireciona para a seleção de filial quando necessário.

**Fase E.0.5 — Replicação matriz→filiais para os 5 Resources "lookup"**
- `TbPaymentType`, `TbCaixa`, `TbTypeLaunch`, `TbBase`, `TbOperation`: toda criação/edição/exclusão feita pelo Filament (sempre contra a matriz) agora replica automaticamente para todas as filiais, via uma nova coluna `id_mtz` em cada tabela (a filial referencia o registro da matriz por `id_mtz`, nunca pelo `id` local — cada banco tem autoincremento independente).
- Novo helper `App\Filament\Support\LookupReplication` + métodos `*WithMtzTracking` em `App\Services\ReplicaDbService` (sem alterar os métodos genéricos existentes, já usados por `TbClosingsService`).
- `TbCaixa` ganhou `use SoftDeletes` (a coluna já existia, nunca era usada) + suporte a lixeira/restaurar, igual ao `TbBaseResource`.
- Roles/Permissions ficam de propósito fora dessa replicação, para manter o controle de acesso centralizado na matriz.

**Fase E.2 — TbLaunchResource unificado**
- Um único Resource pro lançamento (não duas telas separadas de Entrada/Saída como no sistema legado) — o Select de Operação é obrigatório e **sem valor padrão**, forçando escolha explícita a cada lançamento.
- Os demais Selects (Caixa, Tipo de Pagamento, Tipo de Lançamento, Mês de Referência) listam as cópias replicadas da filial ativa.
- Todo o CRUD delega para `App\Services\TbLaunchService` (já existente, já testado em produção) — sem reimplementar bloqueio de período fechado nem a replicação matriz↔filial via `id_filial`/`id_mtz`.
- Ação de aprovar/reprovar checando a permission `launch-approves` (existia cadastrada mas nunca era checada em lugar nenhum) contra a matriz.
- Durante os testes, apareceu um gap de integração real: `TbLaunchService::store()` reconecta pra filial lendo `session('base')` do sistema legado, que uma sessão só-Filament nunca populava. Resolvido com uma ponte de sessão (`ResolvesFilialConnection::withLegacyBaseSessionBridge()`) só ao redor dessa chamada, sem alterar o `TbLaunchService` e sem vazar pra outra aba do sistema legado.

## Test plan

- [x] `php artisan test` — 19/20 passando (única falha é `Tests\Feature\ExampleTest`, pré-existente e não relacionada, reproduzida também na `master` antes destas mudanças).
- [x] `tests/Feature/SelectFilialTest.php` — Admin vê todas as bases; usuário comum só vê as atribuídas; selecionar base não autorizada é rejeitado.
- [x] `tests/Feature/LookupReplicationTest.php` — cria/edita/exclui `TbPaymentType`/`TbCaixa` pelo Filament e confirma a replicação por `id_mtz` em 2 filiais simuladas (sqlite físicos separados), incluindo soft-delete.
- [x] `tests/Feature/TbLaunchResourceTest.php` — criação replica espelho na matriz com `id_filial`/`id_mtz` corretos; período fechado bloqueia a criação; edição propaga pra matriz; aprovação via `TbLaunchService::aprov_id` propaga `status`; a permission gate liga/desliga corretamente.
- [ ] Validação manual em produção (composer install + `php artisan migrate`) — pendente, fora do escopo desta sessão.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH

---
_Generated by [Claude Code](https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH)_