### PR TITLE
Fix: coluna deleted_at faltando em tb_caixa nas filiais (500 em Lançamentos)

### DIFF
--- a/database/migrations/2026_08_27_210000_add_deleted_at_to_tb_caixa_table_if_missing.php
+++ b/database/migrations/2026_08_27_210000_add_deleted_at_to_tb_caixa_table_if_missing.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * A migration original (2021_03_29_000005_create_tb_caixa_table) já cria
+ * `deleted_at` via softDeletes(), mas as bases das filiais (adb_vla/adb_sed)
+ * em produção ficaram sem essa coluna — provavelmente nunca rodaram essa
+ * migration de fato, mesmo com o migrations/migration marcado como já
+ * executado ali. Isso ficou invisível até `TbCaixa` ganhar `use SoftDeletes;`
+ * (Fase E.0.5), que passou a filtrar por `deleted_at` em toda consulta.
+ *
+ * Corrige de forma defensiva, sem depender de refazer o histórico de
+ * migrations em cada conexão: adiciona a coluna só onde estiver faltando.
+ */
+class AddDeletedAtToTbCaixaTableIfMissing extends Migration
+{
+    public function up()
+    {
+        if (! Schema::hasColumn('tb_caixa', 'deleted_at')) {
+            Schema::table('tb_caixa', function (Blueprint $table) {
+                $table->softDeletes();
+            });
+        }
+    }
+
+    public function down()
+    {
+        // Não reverte — a coluna já é esperada pela migration original
+        // (2021_03_29_000005_create_tb_caixa_table); isso só corrige bases
+        // onde ela nunca chegou a existir.
+    }
+}


### PR DESCRIPTION
## Summary

Corrige o erro 500 ao acessar `/admin/tb-launches` em produção.

**Causa raiz** (confirmada via `storage/logs/laravel.log`):
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'tb_caixa.deleted_at' in 'where clause'
(Connection: adb_vla, SQL: select * from `tb_caixa` where `tb_caixa`.`id` in (1) and `tb_caixa`.`deleted_at` is null)
```

A migration original de `tb_caixa` (2021) já cria `deleted_at` via `softDeletes()`, mas a base da filial `adb_vla` (e provavelmente `adb_sed`) nunca teve essa coluna de fato — um desalinhamento de schema antigo entre matriz e filiais, invisível até a PR #140 adicionar `use SoftDeletes;` ao model `TbCaixa`, que passou a filtrar por `deleted_at` em toda consulta (inclusive as que o `TbLaunchResource` faz na filial ativa).

## Fix

Nova migration defensiva (`database/migrations/2026_08_27_210000_add_deleted_at_to_tb_caixa_table_if_missing.php`) que adiciona a coluna **só onde estiver faltando** (`Schema::hasColumn` antes de alterar), sem depender de refazer o histórico de migrations por conexão.

## Passo adicional necessário em produção (fora deste PR)

O `php artisan migrate --force` roda só contra a conexão padrão (matriz). As migrations da Fase E (`user_has_base`, as 5 colunas `id_mtz`, e esta nova) também precisam rodar contra as filiais:

```bash
php artisan migrate --database=adb_vla --path=database/migrations --force
php artisan migrate --database=adb_sed --path=database/migrations --force
```

## Test plan

- [x] `php artisan test` — 19/20 (única falha é `ExampleTest`, pré-existente e não relacionada).
- [x] Migration testada localmente contra sqlite (no-op quando a coluna já existe).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH

---
_Generated by [Claude Code](https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH)_