### PR TITLE
Fix TbLaunch edit 404 and add filial auto-select/badge/switcher UX

### DIFF
--- a/app/Filament/Support/ResolvesFilialConnection.php
+++ b/app/Filament/Support/ResolvesFilialConnection.php
@@ -48,6 +48,37 @@ class ResolvesFilialConnection
     }
 
     /**
+     * Se o painel ainda não tem uma filial selecionada nesta sessão, tenta
+     * herdar automaticamente a mesma base já escolhida no login do sistema
+     * legado (session('id_base'), setada em App\Http\Controllers\Api\Login).
+     * Só copia o id — resolve o registro correspondente contra a matriz e
+     * confirma que o usuário tem acesso a essa base antes de aceitar, então
+     * uma sessão legada inválida/de outro usuário nunca é usada às cegas.
+     *
+     * Não sobrescreve uma escolha já feita no painel: depois da primeira
+     * seleção (automática ou manual), o Filament passa a ser independente
+     * do sistema legado, como já documentado na classe.
+     */
+    public static function autoSelectFromLegacySession($user): void
+    {
+        if (static::currentBase()) {
+            return;
+        }
+
+        $legacyBaseId = session('id_base');
+
+        if (! $legacyBaseId) {
+            return;
+        }
+
+        $match = static::availableBasesFor($user)->firstWhere('id', $legacyBaseId);
+
+        if ($match) {
+            static::setCurrentBase($match);
+        }
+    }
+
+    /**
      * Garante que a conexão do banco está na filial selecionada na sessão.
      * Se nenhuma filial foi selecionada ainda, notifica e interrompe a
      * execução (Halt) — o middleware EnsureFilialSelected cuida de
@@ -86,6 +117,48 @@ class ResolvesFilialConnection
         }
 
         return $user->bases()->orderBy('name')->get();
+    }
+
+    /**
+     * Reconecta pra filial ativa antes do Livewire processar uma ação
+     * (POST /livewire/update) que pertence ao TbLaunchResource.
+     *
+     * A rota /livewire/update é global — registrada pelo próprio pacote
+     * Livewire fora do escopo do painel Filament, com só o middleware
+     * 'web' padrão do Laravel (confirmado via `route:list`) — então
+     * nenhum middleware do painel roda nela, nem ReconnectDbDefault nem
+     * EnsureFilialSelected. Sem essa reconexão, o synthesizer nativo de
+     * Model do Livewire reidrata a propriedade $record (buscando o
+     * registro no banco) usando qualquer conexão que tenha sobrado de
+     * antes — e como os ids de tb_launch só existem mesmo na filial, essa
+     * busca falha e vira 404 (Laravel converte ModelNotFoundException não
+     * capturada em NotFoundHttpException). Isso acontece antes até de
+     * handleRecordUpdate() rodar, então precisa ser resolvido aqui.
+     *
+     * Registrado via Livewire::listen('request', ...) em
+     * App\Providers\Filament\AdminPanelProvider::boot() — o hook 'request'
+     * do próprio Livewire roda pra QUALQUER requisição de update
+     * (independente de painel/rota), exatamente o gancho cedo o
+     * suficiente que um middleware HTTP não consegue oferecer aqui.
+     *
+     * @param  array<int, array{snapshot?: string}>  $requestPayload
+     */
+    public static function reconnectForLivewireUpdateIfNeeded(array $requestPayload): void
+    {
+        if (! static::currentBase()) {
+            return;
+        }
+
+        foreach ($requestPayload as $component) {
+            $snapshot = json_decode($component['snapshot'] ?? '', associative: true);
+            $path = $snapshot['memo']['path'] ?? '';
+
+            if (str_contains($path, 'tb-launches')) {
+                static::assertConnected();
+
+                return;
+            }
+        }
     }
 
     /**

--- a/app/Http/Middleware/Filament/EnsureFilialSelected.php
+++ b/app/Http/Middleware/Filament/EnsureFilialSelected.php
@@ -8,16 +8,31 @@ use Closure;
 use Illuminate\Http\Request;
 
 /**
- * Camada de UX: redireciona para a seleção de filial antes de entrar numa
- * tela que depende dela (hoje só TbLaunchResource). Não é a garantia de
- * correção — essa continua sendo ResolvesFilialConnection::assertConnected()
- * chamado explicitamente dentro dos hooks que tocam o banco (ver
- * app/Filament/Support/ResolvesFilialConnection.php).
+ * Roda em toda requisição do painel, depois de ReconnectDbDefault (que já
+ * forçou a conexão padrão pra matriz). Faz duas coisas:
+ *
+ * 1. Tenta herdar automaticamente a filial já selecionada no sistema legado
+ *    (ResolvesFilialConnection::autoSelectFromLegacySession()) se o painel
+ *    ainda não tem nenhuma selecionada nesta sessão.
+ * 2. Redireciona pra seleção manual de filial antes de entrar numa tela que
+ *    depende dela (hoje só TbLaunchResource) quando não foi possível herdar
+ *    nenhuma.
+ *
+ * Não cobre as ações do Livewire (POST /livewire/update) — essa rota é
+ * global (registrada pelo próprio pacote fora do escopo do painel, com só
+ * o middleware 'web' padrão do Laravel), então nenhum middleware do painel
+ * roda nela. Ver App\Providers\Filament\AdminPanelProvider::boot() para
+ * como a reconexão é garantida ali (hook Livewire::listen('request', ...),
+ * não um middleware HTTP).
  */
 class EnsureFilialSelected
 {
     public function handle(Request $request, Closure $next)
     {
+        if ($user = $request->user()) {
+            ResolvesFilialConnection::autoSelectFromLegacySession($user);
+        }
+
         if (
             $request->routeIs('filament.admin.resources.tb-launches.*')
             && ! ResolvesFilialConnection::currentBase()

--- a/app/Livewire/FilialBadge.php
+++ b/app/Livewire/FilialBadge.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Filament\Support\ResolvesFilialConnection;
+use Livewire\Component;
+
+/**
+ * Badge sempre visível na topbar do painel (antes do menu do usuário) com
+ * o nome da filial ativa. Só leitura — a troca em si é feita pelo
+ * App\Livewire\FilialSwitcher, dentro do menu do usuário.
+ */
+class FilialBadge extends Component
+{
+    public function render()
+    {
+        return view('livewire.filial-badge', [
+            'base' => ResolvesFilialConnection::currentBase(),
+        ]);
+    }
+}

--- a/app/Livewire/FilialSwitcher.php
+++ b/app/Livewire/FilialSwitcher.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Filament\Support\ResolvesFilialConnection;
+use Livewire\Component;
+
+/**
+ * Dropdown de troca rápida de filial, dentro do menu do usuário do painel.
+ * Ao trocar, recarrega a página inteira (não só o componente) — várias
+ * partes do painel só reafirmam a conexão em pontos específicos do ciclo de
+ * vida (ver ResolvesFilialConnection), então um simples "$refresh" do
+ * Livewire poderia deixar a página atual com estado misto de duas filiais.
+ */
+class FilialSwitcher extends Component
+{
+    public ?int $idtbBase = null;
+
+    public function mount(): void
+    {
+        $this->idtbBase = ResolvesFilialConnection::currentBase()['id'] ?? null;
+    }
+
+    public function getBasesProperty()
+    {
+        return ResolvesFilialConnection::availableBasesFor(auth()->user());
+    }
+
+    public function updatedIdtbBase(): void
+    {
+        $base = $this->bases->firstWhere('id', $this->idtbBase);
+
+        if (! $base) {
+            return;
+        }
+
+        ResolvesFilialConnection::setCurrentBase($base);
+
+        $this->redirect(request()->header('Referer') ?: route('filament.admin.pages.dashboard'), navigate: false);
+    }
+
+    public function render()
+    {
+        return view('livewire.filial-switcher');
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Support\ResolvesFilialConnection;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -10,16 +11,31 @@ use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\View\PanelsRenderHook;
 use Filament\Widgets;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Livewire\Livewire;
 
 class AdminPanelProvider extends PanelProvider
 {
+    public function boot(): void
+    {
+        // POST /livewire/update é uma rota global (fora do escopo do
+        // painel, só com o middleware 'web'), então a reconexão pra
+        // filial de TbLaunchResource não pode viver num middleware do
+        // Panel — precisa ser um hook do próprio Livewire. Ver
+        // App\Filament\Support\ResolvesFilialConnection::reconnectForLivewireUpdateIfNeeded().
+        Livewire::listen('request', function (array $requestPayload) {
+            ResolvesFilialConnection::reconnectForLivewireUpdateIfNeeded($requestPayload);
+        });
+    }
+
     public function panel(Panel $panel): Panel
     {
         return $panel
@@ -69,6 +85,17 @@ class AdminPanelProvider extends PanelProvider
             ], isPersistent: true)
             ->authMiddleware([
                 Authenticate::class,
-            ]);
+            ])
+            // Badge com o nome da filial ativa, antes do menu do usuário na
+            // topbar, e o seletor de troca rápida dentro desse menu — ver
+            // App\Livewire\FilialBadge / FilialSwitcher.
+            ->renderHook(
+                PanelsRenderHook::GLOBAL_SEARCH_AFTER,
+                fn (): string => Blade::render('@livewire(\'filial-badge\')'),
+            )
+            ->renderHook(
+                PanelsRenderHook::USER_MENU_PROFILE_AFTER,
+                fn (): string => Blade::render('@livewire(\'filial-switcher\')'),
+            );
     }
 }

--- a/resources/views/livewire/filial-badge.blade.php
+++ b/resources/views/livewire/filial-badge.blade.php
@@ -1,0 +1,13 @@
+<div>
+    @if ($base)
+        <span
+            @class([
+                'fi-badge flex items-center justify-center gap-x-1 rounded-md text-xs font-medium ring-1 ring-inset px-2 min-w-[theme(spacing.6)] py-1',
+                'bg-primary-50 text-primary-700 ring-primary-600/10 dark:bg-primary-400/10 dark:text-primary-400 dark:ring-primary-400/30',
+            ])
+        >
+            <x-heroicon-m-building-office-2 class="h-4 w-4" />
+            {{ $base['name'] }}
+        </span>
+    @endif
+</div>

--- a/resources/views/livewire/filial-switcher.blade.php
+++ b/resources/views/livewire/filial-switcher.blade.php
@@ -1,0 +1,15 @@
+<x-filament::dropdown.list>
+    <div class="fi-dropdown-list-item px-3 py-2">
+        <label class="fi-fo-field-wrp-label mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+            {{ __('Filial') }}
+        </label>
+
+        <x-filament::input.wrapper>
+            <x-filament::input.select wire:model.live="idtbBase">
+                @foreach ($this->bases as $base)
+                    <option value="{{ $base->id }}">{{ $base->name }}</option>
+                @endforeach
+            </x-filament::input.select>
+        </x-filament::input.wrapper>
+    </div>
+</x-filament::dropdown.list>

--- a/tests/Feature/FilialSwitcherTest.php
+++ b/tests/Feature/FilialSwitcherTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Entities\TbBase;
+use App\Entities\TbCadUser;
+use App\Entities\TbProfile;
+use App\Livewire\FilialBadge;
+use App\Livewire\FilialSwitcher;
+use App\Filament\Support\ResolvesFilialConnection;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Badge (topbar, antes do menu do usuário) + seletor rápido (dentro do
+ * menu do usuário) de troca de filial no painel.
+ */
+class FilialSwitcherTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $path = dirname(__DIR__, 2) . '/database/testing.sqlite';
+        if (! file_exists($path)) {
+            touch($path);
+            (new \PDO('sqlite:' . $path))->exec('PRAGMA journal_mode=WAL');
+        }
+
+        $env = 'DB_CONNECTION_MTZ=sqlite DB_DATABASE=database/testing.sqlite APP_ENV=testing';
+        exec("{$env} php artisan migrate --path=database/migrations --force 2>&1");
+        exec("{$env} php artisan migrate --path=database/migrations/only_bd_mtz --force 2>&1");
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['database.connections.adb_mtz' => config('database.connections.sqlite')]);
+    }
+
+    private function makeAdmin(string $email): TbCadUser
+    {
+        Role::findOrCreate('Admin', 'web');
+        $profile = TbProfile::firstOrCreate(['name' => 'Perfil Teste']);
+        $homeBase = TbBase::firstOrCreate(['sigla' => 'SWMTZ'], ['name' => 'Matriz']);
+
+        $user = TbCadUser::firstOrCreate(
+            ['email' => $email],
+            [
+                'name' => $email,
+                'idtb_profile' => $profile->id,
+                'idtb_base' => $homeBase->id,
+                'password' => bcrypt('secret'),
+                'status' => 1,
+            ]
+        );
+
+        if (! $user->hasRole('Admin')) {
+            $user->assignRole('Admin');
+        }
+
+        return $user;
+    }
+
+    public function test_badge_shows_nothing_when_no_filial_is_selected(): void
+    {
+        $admin = $this->makeAdmin('badge-none@example.com');
+        ResolvesFilialConnection::clearCurrentBase();
+
+        Livewire::actingAs($admin)
+            ->test(FilialBadge::class)
+            ->assertDontSeeHtml('fi-badge');
+    }
+
+    public function test_badge_shows_the_current_filial_name(): void
+    {
+        $admin = $this->makeAdmin('badge-shows@example.com');
+        $base = TbBase::firstOrCreate(['sigla' => 'SWBADGE'], ['name' => 'Filial do Badge']);
+        ResolvesFilialConnection::setCurrentBase($base);
+
+        Livewire::actingAs($admin)
+            ->test(FilialBadge::class)
+            ->assertSee('Filial do Badge');
+    }
+
+    public function test_switcher_lists_bases_available_to_the_user_with_the_current_one_selected(): void
+    {
+        $admin = $this->makeAdmin('switcher-list@example.com');
+        $base = TbBase::firstOrCreate(['sigla' => 'SWLIST'], ['name' => 'Filial da Lista']);
+        ResolvesFilialConnection::setCurrentBase($base);
+
+        Livewire::actingAs($admin)
+            ->test(FilialSwitcher::class)
+            ->assertSet('idtbBase', $base->id)
+            ->assertSeeHtml('Filial da Lista');
+    }
+
+    public function test_switcher_changes_the_active_filial_and_redirects(): void
+    {
+        $admin = $this->makeAdmin('switcher-change@example.com');
+        $current = TbBase::firstOrCreate(['sigla' => 'SWFROM'], ['name' => 'De Onde']);
+        $target = TbBase::firstOrCreate(['sigla' => 'SWTO'], ['name' => 'Para Onde']);
+        ResolvesFilialConnection::setCurrentBase($current);
+
+        Livewire::actingAs($admin)
+            ->test(FilialSwitcher::class)
+            ->set('idtbBase', $target->id)
+            ->assertRedirect();
+
+        $this->assertSame($target->id, ResolvesFilialConnection::currentBase()['id'] ?? null);
+    }
+}

--- a/tests/Feature/SelectFilialTest.php
+++ b/tests/Feature/SelectFilialTest.php
@@ -106,4 +106,49 @@ class SelectFilialTest extends TestCase
 
         $this->assertNull(session('filament.base'));
     }
+
+    public function test_entering_the_panel_auto_selects_the_same_base_as_the_legacy_session(): void
+    {
+        $admin = $this->makeUser('auto-select-admin@example.com', 'Admin');
+        $legacyBase = TbBase::firstOrCreate(['sigla' => 'AUTO1'], ['name' => 'Auto Filial']);
+
+        $this->actingAs($admin);
+        session(['id_base' => $legacyBase->id]);
+
+        $this->get('/admin')->assertSuccessful();
+
+        $this->assertSame($legacyBase->id, session('filament.base')['id'] ?? null);
+    }
+
+    public function test_auto_select_does_not_override_an_already_selected_base(): void
+    {
+        $admin = $this->makeUser('auto-select-admin2@example.com', 'Admin');
+        $manual = TbBase::firstOrCreate(['sigla' => 'AUTO2'], ['name' => 'Escolhida à mão']);
+        $legacyBase = TbBase::firstOrCreate(['sigla' => 'AUTO3'], ['name' => 'Da sessão legada']);
+
+        $this->actingAs($admin);
+        \App\Filament\Support\ResolvesFilialConnection::setCurrentBase($manual);
+        session(['id_base' => $legacyBase->id]);
+
+        $this->get('/admin')->assertSuccessful();
+
+        $this->assertSame($manual->id, session('filament.base')['id'] ?? null);
+    }
+
+    public function test_auto_select_ignores_a_legacy_base_the_user_cannot_access(): void
+    {
+        // Chamado direto (não via HTTP): usuários sem role Admin não
+        // acessam o painel de jeito nenhum hoje (TbCadUser::canAccessPanel()
+        // exige hasRole('Admin')), então esse caso nunca ocorre pelo
+        // navegador — mas a proteção continua valendo por baixo, caso isso
+        // mude no futuro.
+        $user = $this->makeUser('auto-select-nonadmin@example.com', null);
+        $inaccessible = TbBase::firstOrCreate(['sigla' => 'AUTO4'], ['name' => 'Sem acesso']);
+
+        session(['id_base' => $inaccessible->id]);
+
+        \App\Filament\Support\ResolvesFilialConnection::autoSelectFromLegacySession($user->fresh());
+
+        $this->assertNull(session('filament.base'));
+    }
 }

--- a/tests/Feature/TbLaunchResourceTest.php
+++ b/tests/Feature/TbLaunchResourceTest.php
@@ -275,6 +275,121 @@ class TbLaunchResourceTest extends TestCase
         $this->assertSame('atualizado', TbLaunch::find($idMtz)->description);
     }
 
+    /**
+     * Regressão de produção: editar e salvar um Lançamento dava 404 no
+     * POST /livewire/update. Causa raiz: o synthesizer nativo do Livewire
+     * reidrata a propriedade $record (buscando o Model no banco) ANTES de
+     * qualquer código nosso rodar — e como cada requisição HTTP passa de
+     * novo pelo middleware ReconnectDbDefault (que sempre força a conexão
+     * pra matriz), essa busca falha pra um id que só existe na filial,
+     * virando 404 (Laravel converte ModelNotFoundException não capturada
+     * em NotFoundHttpException).
+     *
+     * Livewire::test() não reproduz isso — ele monta o componente
+     * diretamente, sem passar pelo pipeline de middleware HTTP do painel.
+     * Por isso este teste faz uma requisição HTTP de verdade: GET na
+     * página de edição (extraindo o wire:snapshot do HTML, exatamente
+     * como o navegador faz) seguido de um POST real em /livewire/update
+     * simulando o clique em "Salvar alterações", com a conexão
+     * deliberadamente resetada pra matriz entre as duas chamadas — a
+     * mesma condição de cada requisição real em produção.
+     */
+    public function test_editing_a_launch_via_a_real_http_request_does_not_404(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        // O bug só se manifesta quando o id local da filial não existe *de
+        // jeito nenhum* na matriz (aí sim vira ModelNotFoundException/404).
+        // Numa base de teste zerada, criar 1 lançamento faz o id da filial
+        // (autoincrement raso) coincidir com QUALQUER registro de id baixo
+        // que porventura exista na matriz — inclusive um espelho de outro
+        // lançamento — mascarando o bug (a hidratação "erra a conexão" mas
+        // ainda assim acha alguma linha, sem lançar exceção). Inflar o
+        // autoincrement da FILIAL (não da matriz) garante um id local alto
+        // o bastante pra não existir na matriz, reproduzindo de fato a
+        // situação de produção (onde a matriz acumula histórico de todas
+        // as filiais e tem autoincrement muito mais avançado que qualquer
+        // uma isolada — o oposto do que uma base de teste zerada produz).
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        DB::connection('adb_vla')->table('tb_launch')->insert(array_fill(0, 50, [
+            'id_user' => $admin->id, 'description' => 'preenchimento', 'operation_date' => '2026-01-01',
+            'value' => 1, 'idtb_operation' => 1, 'idtb_type_launch' => 1, 'idtb_payment_type' => 1,
+            'idtb_caixa' => 1, 'idtb_base' => 1, 'status' => 0, 'idtb_closing' => 1,
+        ]));
+        app(ConnectDbController::class)->connectMatriz();
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 100,
+                'description' => 'http-original',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $filialLaunch = TbLaunch::where('description', 'http-original')->firstOrFail();
+        $idMtz = $filialLaunch->id_mtz;
+        app(ConnectDbController::class)->connectMatriz();
+
+        $html = $this->get("/admin/tb-launches/{$filialLaunch->id}/edit")->assertOk()->getContent();
+
+        preg_match_all('/wire:snapshot="([^"]+)"/', $html, $allMatches);
+        $this->assertNotEmpty($allMatches[1] ?? [], 'wire:snapshot não encontrado no HTML da página de edição');
+
+        $matches = null;
+        foreach ($allMatches[1] as $candidate) {
+            if (str_contains($candidate, 'edit-tb-launch')) {
+                $matches = [null, $candidate];
+                break;
+            }
+        }
+        $this->assertNotNull($matches, 'snapshot do componente EditTbLaunch não encontrado (achou ' . count($allMatches[1]) . ' snapshots no total)');
+
+        // O snapshot embutido no HTML fica intacto (igual ao navegador faz)
+        // — o Livewire valida sua integridade via checksum, então mudar de
+        // valor exigiria recalcular esse checksum. Salvar sem alterar nada
+        // já é suficiente pra reproduzir o bug: ele acontece na hidratação
+        // de $record, antes de qualquer campo ser processado.
+        $snapshot = htmlspecialchars_decode($matches[1]);
+
+        // Nova requisição PHP "de verdade": ReconnectDbDefault força a
+        // conexão de volta pra matriz, exatamente como aconteceria numa
+        // requisição HTTP real subsequente. DB::purge() descarta qualquer
+        // PDO já aberto pra filial, pra não mascarar o bug com uma conexão
+        // "presa" que só existe porque tudo roda no mesmo processo PHP do
+        // PHPUnit (em produção cada requisição é um processo à parte, sem
+        // nada em comum entre o GET e o POST além da sessão/banco).
+        DB::purge('adb_vla');
+        DB::purge('adb_mtz');
+        app(ConnectDbController::class)->connectMatriz();
+
+        $response = $this->postJson('/livewire/update', [
+            'components' => [[
+                'snapshot' => $snapshot,
+                'updates' => [],
+                'calls' => [['path' => '', 'method' => 'save', 'params' => []]],
+            ]],
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonMissing(['status' => 404]);
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $this->assertNotNull(TbLaunch::find($filialLaunch->id), 'Lançamento não encontrado na filial após salvar');
+
+        app(ConnectDbController::class)->connectMatriz();
+        $this->assertNotNull(TbLaunch::find($idMtz), 'Espelho na matriz não encontrado após salvar');
+    }
+
     public function test_approving_a_launch_via_the_service_mirrors_the_status_to_the_matriz(): void
     {
         $this->seedFilial();


### PR DESCRIPTION
## Summary

- Fixes a production 404 when editing and saving a Lançamento (`POST /livewire/update`): Livewire's native Eloquent Model synthesizer rehydrates `EditRecord::$record` from the database *before* any panel code runs. Since `/livewire/update` is a global Livewire route registered outside the Filament panel's middleware scope, none of the panel's custom middlewares (which normally reconnect to the active filial) ever ran for it — the connection stayed on the matriz, and filial-only ids failed to resolve. Fixed by hooking `Livewire::listen('request', ...)` in `AdminPanelProvider::boot()`, which fires early enough for any `/livewire/update` request regardless of route/panel scope.
- Auto-selects the active filial when entering `/admin`, reusing the same base already chosen in the legacy system's session (`session('id_base')`), when the panel doesn't have one selected yet for that session. Doesn't override a base already chosen inside the panel, and only accepts a legacy base the user is actually authorized to access.
- Replaces the standalone filial-switch page with a `Select` inside the user menu dropdown (`App\Livewire\FilialSwitcher`).
- Adds a badge in the topbar, before the user menu, showing the name of the filial currently active (`App\Livewire\FilialBadge`).

## Test plan

- [x] `php artisan test` — 27/28 passing (only failure is the pre-existing unrelated `Tests\Feature\ExampleTest`, reproducible on `master` before this change).
- [x] New regression test `TbLaunchResourceTest::test_editing_a_launch_via_a_real_http_request_does_not_404` — makes a genuine HTTP `GET` + `POST /livewire/update` round trip (not `Livewire::test()`, which doesn't reproduce the bug since it bypasses the HTTP middleware pipeline entirely), confirmed to fail with the same 404 signature as production without the fix, and pass with it.
- [x] New tests in `SelectFilialTest` covering auto-select from the legacy session (inherits, doesn't override a manual choice, ignores an unauthorized base).
- [x] New `FilialSwitcherTest` covering the badge and switcher components.
- [ ] Manual verification in production once deployed: editing/saving a Lançamento no longer 404s, the badge shows the right filial name, the switcher works from the user menu, and entering `/admin` auto-selects the same base as the legacy session.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH)_