### PR TITLE
Reset a launch to pending status when edited

### DIFF
--- a/app/Services/TbLaunchService.php
+++ b/app/Services/TbLaunchService.php
@@ -148,6 +148,9 @@ class TbLaunchService
       }
 
 
+      //editar um lançamento já aprovado exige nova aprovação
+      $data['status'] = 0;
+
       //atualiza lançamento no banco de dados filial
       $launch = $this->repository->update($data, $id);
       //recupera id_mtz

--- a/tests/Feature/TbLaunchResourceTest.php
+++ b/tests/Feature/TbLaunchResourceTest.php
@@ -275,6 +275,61 @@ class TbLaunchResourceTest extends TestCase
         $this->assertSame('atualizado', TbLaunch::find($idMtz)->description);
     }
 
+    public function test_editing_an_approved_launch_reverts_it_to_pending(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 100,
+                'description' => 'a reabrir',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $filialLaunch = TbLaunch::where('description', 'a reabrir')->firstOrFail();
+        $idMtz = $filialLaunch->id_mtz;
+
+        $result = app(\App\Services\TbLaunchService::class)->aprov_id([
+            'id' => $filialLaunch->id,
+            'status' => 1,
+        ]);
+        $this->assertTrue($result['success']);
+        $this->assertSame(1, (int) TbLaunch::find($filialLaunch->id)->status);
+        app(ConnectDbController::class)->connectMatriz();
+
+        Livewire::test(EditTbLaunch::class, ['record' => $filialLaunch->getKey()])
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 150,
+                'description' => 'reaberto',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $this->assertSame(0, (int) TbLaunch::find($filialLaunch->id)->status);
+
+        app(ConnectDbController::class)->connectMatriz();
+        $this->assertSame(0, (int) TbLaunch::find($idMtz)->status);
+    }
+
     /**
      * Regressão de produção: editar e salvar um Lançamento dava 404 no
      * POST /livewire/update. Causa raiz: o synthesizer nativo do Livewire


### PR DESCRIPTION
## Summary

- Editing an already-approved Lançamento left its `status` untouched (`TbLaunchRepository::update()`, from `prettus/l5-repository`, only fills the attributes it's given — it never resets fields the caller doesn't pass). So an approved launch stayed approved after an edit, with no re-review.
- `TbLaunchService::update()` now explicitly sets `status = 0` (pendente) before updating both the filial record and its matriz mirror, so any edit — from the legacy Blade flow or the Filament `TbLaunchResource` — always sends the launch back to pending.

## Test plan

- [x] New test `TbLaunchResourceTest::test_editing_an_approved_launch_reverts_it_to_pending` — approves a launch via `TbLaunchService::aprov_id`, edits it through `EditTbLaunch`, and asserts `status` is back to `0` on both the filial and the matriz mirror.
- [x] `php artisan test` — 28/29 passing (only failure is the pre-existing unrelated `Tests\Feature\ExampleTest`).


---
_Generated by [Claude Code](https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH)_