### PR TITLE
Fix matriz 404 on launch edit; restrict CRUD to the filial base

### DIFF
--- a/app/Filament/Resources/TbLaunchResource.php
+++ b/app/Filament/Resources/TbLaunchResource.php
@@ -51,12 +51,38 @@ class TbLaunchResource extends Resource
         return auth()->user()?->hasRole('Admin') ?? false;
     }
 
+    /**
+     * Criar lançamento só faz sentido a partir de uma filial (o lançamento
+     * precisa nascer associado a uma base física) — a matriz só visualiza
+     * (todas as filiais têm sua cópia espelhada lá, ver TbLaunchService).
+     */
+    public static function canCreate(): bool
+    {
+        return ! ResolvesFilialConnection::currentBaseIsMatriz();
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
                 Forms\Components\Section::make('Dados do Lançamento')
                     ->schema([
+                        // TbLaunchService::update()/aprov_id() partem do
+                        // pressuposto de que a conexão ativa é a filial (usam
+                        // id_mtz do registro pra achar o espelho na matriz) —
+                        // na matriz esse valor não existe no registro em si
+                        // (só id_filial), então editar de lá quebraria com
+                        // "No query results for model". Por isso o form
+                        // inteiro fica somente leitura quando a base ativa é
+                        // a matriz, e mostra a filial de origem em texto.
+                        Forms\Components\TextInput::make('baseName')
+                            ->label('Base')
+                            ->disabled()
+                            ->dehydrated(false)
+                            ->visible(fn (string $operation): bool => $operation === 'edit' && ResolvesFilialConnection::currentBaseIsMatriz())
+                            ->afterStateHydrated(function (Forms\Components\TextInput $component, ?TbLaunch $record) {
+                                $component->state($record?->base?->name);
+                            }),
                         Forms\Components\Select::make('id_user')
                             ->label('Lançado por')
                             ->relationship('user', 'name')
@@ -107,7 +133,8 @@ class TbLaunchResource extends Resource
                             ->columnSpanFull(),
                     ])
                     ->columns(2)
-                    ->columnSpanFull(),
+                    ->columnSpanFull()
+                    ->disabled(fn (string $operation): bool => $operation === 'edit' && ResolvesFilialConnection::currentBaseIsMatriz()),
             ]);
     }
 
@@ -118,6 +145,9 @@ class TbLaunchResource extends Resource
                 Tables\Columns\TextColumn::make('operation_date')
                     ->label('Data')
                     ->date('d/m/Y')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('base.name')
+                    ->label('Base')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('operation.name')
                     ->label('Operação')
@@ -163,18 +193,32 @@ class TbLaunchResource extends Resource
                     ->icon('heroicon-o-check-circle')
                     ->color('success')
                     ->requiresConfirmation()
-                    ->visible(fn (TbLaunch $record): bool => $record->status != 1 && static::userCanApprove())
+                    ->visible(fn (TbLaunch $record): bool => $record->status != 1 && static::userCanApprove() && ! ResolvesFilialConnection::currentBaseIsMatriz())
                     ->action(fn (TbLaunch $record) => static::approve($record, 1)),
                 Tables\Actions\Action::make('reprovar')
                     ->label('Reprovar')
                     ->icon('heroicon-o-x-circle')
                     ->color('danger')
                     ->requiresConfirmation()
-                    ->visible(fn (TbLaunch $record): bool => $record->status != 2 && static::userCanApprove())
+                    ->visible(fn (TbLaunch $record): bool => $record->status != 2 && static::userCanApprove() && ! ResolvesFilialConnection::currentBaseIsMatriz())
                     ->action(fn (TbLaunch $record) => static::approve($record, 2)),
                 Tables\Actions\DeleteAction::make()
+                    ->visible(fn (): bool => ! ResolvesFilialConnection::currentBaseIsMatriz())
                     ->action(function (TbLaunch $record) {
                         ResolvesFilialConnection::assertConnected();
+
+                        // Reforço além do ->visible(): TbLaunchService::delete()
+                        // também parte do pressuposto de que a conexão ativa é
+                        // a filial (usa id_mtz do registro pra achar o espelho
+                        // na matriz).
+                        if (ResolvesFilialConnection::currentBaseIsMatriz()) {
+                            Notification::make()
+                                ->title('Exclusão só pode ser feita a partir da base filial')
+                                ->danger()
+                                ->send();
+
+                            return;
+                        }
 
                         app(TbLaunchService::class)->delete($record->id);
 
@@ -211,6 +255,19 @@ class TbLaunchResource extends Resource
     protected static function approve(TbLaunch $record, int $status): void
     {
         ResolvesFilialConnection::assertConnected();
+
+        // Reforço além do ->visible() das actions: TbLaunchService::aprov_id()
+        // parte do pressuposto de que a conexão ativa é a filial (usa id_mtz
+        // do registro pra achar o espelho na matriz) — quebraria com "No
+        // query results for model" se chamado com a matriz ativa.
+        if (ResolvesFilialConnection::currentBaseIsMatriz()) {
+            Notification::make()
+                ->title('Aprovação só pode ser feita a partir da base filial')
+                ->danger()
+                ->send();
+
+            return;
+        }
 
         $result = app(TbLaunchService::class)->aprov_id([
             'id' => $record->id,

--- a/app/Filament/Resources/TbLaunchResource/Pages/EditTbLaunch.php
+++ b/app/Filament/Resources/TbLaunchResource/Pages/EditTbLaunch.php
@@ -22,9 +22,38 @@ class EditTbLaunch extends EditRecord
         parent::mount($record);
     }
 
+    /**
+     * Editar (de fato salvar) só é permitido a partir da própria filial —
+     * a página em si continua acessível com a matriz ativa (o form fica
+     * somente leitura, ver TbLaunchResource::form()), pra permitir consultar
+     * o lançamento de qualquer base sem precisar trocar de filial. Por isso
+     * o botão "Salvar" some, mas "Cancelar" continua disponível.
+     */
+    protected function getFormActions(): array
+    {
+        if (ResolvesFilialConnection::currentBaseIsMatriz()) {
+            return [$this->getCancelFormAction()];
+        }
+
+        return parent::getFormActions();
+    }
+
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
         ResolvesFilialConnection::assertConnected();
+
+        // Reforço além do form somente-leitura/botão oculto: TbLaunchService::update()
+        // parte do pressuposto de que a conexão ativa é a filial (usa id_mtz
+        // do registro pra achar o espelho na matriz) — quebraria com "No
+        // query results for model" se chamado com a matriz ativa.
+        if (ResolvesFilialConnection::currentBaseIsMatriz()) {
+            Notification::make()
+                ->title('Edição só pode ser feita a partir da base filial')
+                ->danger()
+                ->send();
+
+            throw new Halt();
+        }
 
         $user = TbCadUser::find($data['id_user']);
         $data['name'] = $user?->name;

--- a/app/Filament/Support/ResolvesFilialConnection.php
+++ b/app/Filament/Support/ResolvesFilialConnection.php
@@ -48,6 +48,16 @@ class ResolvesFilialConnection
     }
 
     /**
+     * A matriz usa sempre a sigla/conexão 'adb_mtz' — mesma convenção já
+     * usada em App\Services\ReplicaDbService e nos middlewares legados de
+     * rota (RouteAccessesMatriz/RouteAccessesFilial).
+     */
+    public static function currentBaseIsMatriz(): bool
+    {
+        return (static::currentBase()['sigla'] ?? null) === 'adb_mtz';
+    }
+
+    /**
      * Se o painel ainda não tem uma filial selecionada nesta sessão, tenta
      * herdar automaticamente a mesma base já escolhida no login do sistema
      * legado (session('id_base'), setada em App\Http\Controllers\Api\Login).

--- a/tests/Feature/TbLaunchResourceTest.php
+++ b/tests/Feature/TbLaunchResourceTest.php
@@ -521,4 +521,146 @@ class TbLaunchResourceTest extends TestCase
         // a conexão pra filial ativa da sessão ao terminar.
         $this->assertSame(self::$vlaPath, DB::connection()->getConfig('database'));
     }
+
+    /**
+     * Regressão: TbLaunchService::update()/aprov_id()/delete() partem do
+     * pressuposto de que a conexão ativa é a filial (usam id_mtz do registro
+     * pra achar o espelho na matriz) — chamá-los com a matriz ativa quebrava
+     * com "No query results for model [App\Entities\TbLaunch]." (a cópia da
+     * matriz não tem id_mtz preenchido, só id_filial). Por decisão de
+     * produto, alterar/criar/excluir só é permitido a partir da própria
+     * filial; a matriz só visualiza (todas as filiais já têm cópia
+     * espelhada lá).
+     */
+    public function test_create_action_and_route_are_blocked_when_current_base_is_matriz(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        app(ConnectDbController::class)->connectMatriz();
+        $matriz = TbBase::where('sigla', 'adb_mtz')->firstOrFail();
+        ResolvesFilialConnection::setCurrentBase($matriz);
+
+        $this->assertFalse(\App\Filament\Resources\TbLaunchResource::canCreate());
+        $this->get('/admin/tb-launches/create')->assertForbidden();
+    }
+
+    public function test_editing_a_launch_from_matriz_is_read_only_and_does_not_crash(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 75,
+                'description' => 'visto pela matriz',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $filialLaunch = TbLaunch::where('description', 'visto pela matriz')->firstOrFail();
+        app(ConnectDbController::class)->connectMatriz();
+        $matrizLaunch = TbLaunch::where('id_filial', $filialLaunch->id)->firstOrFail();
+        $matriz = TbBase::where('sigla', 'adb_mtz')->firstOrFail();
+        ResolvesFilialConnection::setCurrentBase($matriz);
+
+        Livewire::test(EditTbLaunch::class, ['record' => $matrizLaunch->getKey()])
+            ->assertFormFieldIsVisible('baseName')
+            ->assertFormSet(['baseName' => 'Filial Vila'])
+            ->assertFormFieldIsDisabled('value')
+            ->assertFormFieldIsDisabled('description')
+            ->call('save');
+
+        app(ConnectDbController::class)->connectMatriz();
+        $this->assertSame('visto pela matriz', TbLaunch::find($matrizLaunch->id)->description);
+    }
+
+    public function test_delete_and_approve_actions_are_hidden_and_blocked_when_current_base_is_matriz(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        app(ConnectDbController::class)->connectMatriz();
+        Permission::findOrCreate('launch-approves', 'web');
+        $admin->givePermissionTo('launch-approves');
+        app(ConnectDbController::class)->connectBases('adb_vla');
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 30,
+                'description' => 'não mexer pela matriz',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $filialLaunch = TbLaunch::where('description', 'não mexer pela matriz')->firstOrFail();
+        app(ConnectDbController::class)->connectMatriz();
+        $matrizLaunch = TbLaunch::where('id_filial', $filialLaunch->id)->firstOrFail();
+        $matriz = TbBase::where('sigla', 'adb_mtz')->firstOrFail();
+        ResolvesFilialConnection::setCurrentBase($matriz);
+
+        $cache = new \ReflectionProperty(\App\Filament\Resources\TbLaunchResource::class, 'canApproveCache');
+        $cache->setAccessible(true);
+        $cache->setValue(null, null);
+
+        // callTableAction() já se recusa a chamar uma action escondida (imita
+        // a UI real, onde o botão nem aparece pra clicar) — então as
+        // asserções de visibilidade abaixo são a própria prova de que
+        // delete/aprovar/reprovar estão bloqueadas pela matriz.
+        Livewire::test(\App\Filament\Resources\TbLaunchResource\Pages\ListTbLaunches::class)
+            ->assertTableActionHidden('delete', $matrizLaunch)
+            ->assertTableActionHidden('aprovar', $matrizLaunch)
+            ->assertTableActionHidden('reprovar', $matrizLaunch);
+
+        app(ConnectDbController::class)->connectMatriz();
+        $this->assertNotNull(TbLaunch::find($matrizLaunch->id), 'Registro da matriz não deveria ter sido excluído');
+
+        app(ConnectDbController::class)->connectBases('adb_vla');
+        $this->assertNotNull(TbLaunch::find($filialLaunch->id), 'Registro da filial não deveria ter sido excluído');
+    }
+
+    public function test_table_shows_the_base_column(): void
+    {
+        $this->seedFilial();
+        $admin = $this->actingAsAdmin();
+        $this->actingAs($admin);
+
+        Livewire::test(CreateTbLaunch::class)
+            ->fillForm([
+                'id_user' => $admin->id,
+                'idtb_operation' => 1,
+                'idtb_type_launch' => 1,
+                'idtb_payment_type' => 1,
+                'idtb_caixa' => 1,
+                'idtb_closing' => 1,
+                'operation_date' => '2026-08-15',
+                'value' => 20,
+                'description' => 'com coluna de base',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        Livewire::test(\App\Filament\Resources\TbLaunchResource\Pages\ListTbLaunches::class)
+            ->assertTableColumnExists('base.name')
+            ->assertCanSeeTableRecords(TbLaunch::where('description', 'com coluna de base')->get());
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes "Não foi possível atualizar o lançamento / No query results for model [App\Entities\TbLaunch]." when editing a Lançamento while the panel's active base is the matriz. `TbLaunchService::update()`/`aprov_id()`/`delete()` all assume the active connection is a filial (they read the record's `id_mtz` to locate its matriz mirror) — the matriz's own copy of a launch only has `id_filial` set, not `id_mtz`, so that lookup failed.
- Per the requested access model: creating, editing, deleting, and approving/disapproving a Lançamento are now restricted to when a filial is the active base — the matriz only browses (it already holds a mirrored copy of every filial's launches).
  - "Nova" (create) is hidden and the `/create` route 403s when the matriz is active (`TbLaunchResource::canCreate()`).
  - Delete/Aprovar/Reprovar row actions are hidden when the matriz is active, with a defensive guard (matching notification) in case they're triggered anyway.
  - The edit page stays reachable from the matriz as a read-only view (all fields disabled, "Salvar" hidden, only "Cancelar" shown) so a launch can still be inspected without switching filial — `handleRecordUpdate()` also guards against a bypassed save.
- Added a "Base" column to the table (`base.name`) so browsing from the matriz shows which filial each row belongs to, and a disabled "Base" text field in the edit form, shown only when viewing from the matriz.

## Test plan

- [x] New tests in `TbLaunchResourceTest`: create action/route blocked from matriz; editing from matriz is read-only and doesn't crash or change data; delete/aprovar/reprovar hidden from matriz; the Base column exists and shows rows.
- [x] `php artisan test` — 32/33 passing (only failure is the pre-existing unrelated `Tests\Feature\ExampleTest`).


---
_Generated by [Claude Code](https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH)_