### PR TITLE
Add Laravel Sail for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,16 +6,33 @@ APP_URL=http://localhost
 
 LOG_CHANNEL=stack
 
-DB_CONNECTION_MTZ=mysql
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_DATABASE=homestead
-DB_USERNAME=homestead
-DB_PASSWORD=secret
+# Necessário pro login nativo do painel Filament (/admin) funcionar — sem
+# isso o seeder grava a senha em texto puro e Auth::attempt falha.
+PASSWORD_HASH=true
 
-DB_DATABASE_VLA=homestead
-DB_USERNAME_VLA=homestead
-DB_PASSWORD_VLA=secret
+# DB_HOST/DB_PORT valem pras três conexões (matriz + filiais), que sempre
+# vivem no mesmo host — ver config/database.php. Rodando via Sail
+# (./vendor/bin/sail up), use DB_HOST=mysql (nome do serviço no
+# docker-compose.yml); rodando PHP direto no host, use DB_HOST=127.0.0.1.
+DB_CONNECTION_MTZ=adb_mtz
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=adb_mtz
+DB_USERNAME=sail
+DB_PASSWORD=password
+
+DB_DATABASE_VLA=adb_vla
+DB_USERNAME_VLA=sail
+DB_PASSWORD_VLA=password
+
+DB_DATABASE_SED=adb_sed
+DB_USERNAME_SED=sail
+DB_PASSWORD_SED=password
+
+# Portas expostas ao host pelo docker-compose.yml (Sail) — mude aqui se
+# 80/3306 já estiverem em uso na sua máquina.
+APP_PORT=80
+FORWARD_DB_PORT=3306
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "beyondcode/laravel-dump-server": "^1.0",
         "fakerphp/faker": "^1.23",
         "filp/whoops": "^2.0",
+        "laravel/sail": "^1.67",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^7.0",
         "phpunit/phpunit": "^10.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac17d3b84fb5daa2787a3220886762fb",
+    "content-hash": "70247993e5057995ef7d0012a8c4e4ed",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -9242,6 +9242,69 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v3.0.0"
             },
             "time": "2026-03-17T11:56:53+00:00"
+        },
+        {
+            "name": "laravel/sail",
+            "version": "v1.67.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sail.git",
+                "reference": "639e03ac12cf23def171770bcab05758045b2642"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/639e03ac12cf23def171770bcab05758045b2642",
+                "reference": "639e03ac12cf23def171770bcab05758045b2642",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^9.52.16|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/yaml": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
+                "phpstan/phpstan": "^2.0"
+            },
+            "bin": [
+                "bin/sail"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sail\\SailServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sail\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Docker files for running a basic Laravel application.",
+            "keywords": [
+                "docker",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sail/issues",
+                "source": "https://github.com/laravel/sail"
+            },
+            "time": "2026-08-12T13:55:56+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+services:
+    laravel.test:
+        build:
+            context: ./vendor/laravel/sail/runtimes/8.2
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-8.2/app
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        ports:
+            - '${APP_PORT:-80}:80'
+            - '${VITE_PORT:-5173}:5173'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - mysql
+
+    mysql:
+        image: 'mysql:8.0'
+        ports:
+            - '${FORWARD_DB_PORT:-3306}:3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: '%'
+            MYSQL_DATABASE: '${DB_DATABASE}'
+            MYSQL_USER: '${DB_USERNAME}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 1
+        volumes:
+            - 'sail-mysql:/var/lib/mysql'
+            # As filiais (adb_vla/adb_sed) são bancos à parte na mesma
+            # instância MySQL — MYSQL_DATABASE só cria a matriz
+            # automaticamente, então este script cria o resto no primeiro
+            # boot do container (ver docker/mysql/create-filial-databases.sh).
+            - './docker/mysql/create-filial-databases.sh:/docker-entrypoint-initdb.d/10-create-filial-databases.sh'
+        networks:
+            - sail
+        healthcheck:
+            test:
+                - CMD
+                - mysqladmin
+                - ping
+                - '-p${DB_PASSWORD}'
+            retries: 3
+            timeout: 5s
+
+networks:
+    sail:
+        driver: bridge
+
+volumes:
+    sail-mysql:
+        driver: local

--- a/docker/mysql/create-filial-databases.sh
+++ b/docker/mysql/create-filial-databases.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# O container mysql só cria automaticamente o banco de MYSQL_DATABASE
+# (adb_mtz, a matriz) — as filiais (adb_vla, adb_sed) são bancos à parte
+# na mesma conexão MySQL (mesmo host/porta, ver config/database.php) e
+# precisam ser criados aqui, no bootstrap inicial do container.
+
+mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
+    CREATE DATABASE IF NOT EXISTS adb_vla;
+    CREATE DATABASE IF NOT EXISTS adb_sed;
+EOSQL
+
+if [ -n "$MYSQL_USER" ]; then
+mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
+    GRANT ALL PRIVILEGES ON \`adb_%\`.* TO '$MYSQL_USER'@'%';
+    FLUSH PRIVILEGES;
+EOSQL
+fi


### PR DESCRIPTION
## Summary

- Adds `laravel/sail` as a dev dependency and a Sail-style `docker-compose.yml` (PHP 8.2 runtime, matching `composer.json`'s `^8.1` requirement), replacing the need to hand-roll Docker commands — a single `mysql:8.0` service plus the `laravel.test` app container built straight from Sail's own runtime image (no custom Dockerfile needed; it already ships `php8.2-intl`, `php8.2-mysql`, etc., everything Filament needs).
- Since the app runs three separate connections against the same MySQL host (matriz + 2 filiais, see `config/database.php`), `docker/mysql/create-filial-databases.sh` runs on the MySQL container's first boot to create `adb_vla`/`adb_sed` alongside the matriz database (which the image already creates from `MYSQL_DATABASE`), and grants the app's user access to all three.
- Fixes up `.env.example` along the way:
  - `DB_CONNECTION_MTZ` was set to `mysql` — a connection name that doesn't exist in `config/database.php` (only `adb_mtz`/`adb_vla`/`adb_sed` do), so every environment following this file was pointed at a broken default. Fixed to `adb_mtz`.
  - Adds the previously-missing `DB_DATABASE_SED`/`DB_USERNAME_SED`/`DB_PASSWORD_SED` (`config/database.php` reads them, `.env.example` never defined them).
  - Adds Sail's `APP_PORT`/`FORWARD_DB_PORT`.
  - Adds `PASSWORD_HASH=true` — needed for the Filament panel's native login; without it the seeded admin password is stored in plain text and `Auth::attempt` fails.
- The existing `docker-compose.yaml`/`Dockerfile` (nginx + php-fpm, closer to the shared-hosting deploy shape) are left untouched — this is a separate, additive local dev workflow.

## Usage

```bash
composer install
cp .env.example .env
./vendor/bin/sail up -d
./vendor/bin/sail artisan key:generate
./vendor/bin/sail artisan migrate --force
./vendor/bin/sail artisan migrate --database=adb_vla --path=database/migrations --force
./vendor/bin/sail artisan db:seed
```
App: http://localhost — Filament panel: http://localhost/admin (`admin@vla.com.br` / `adbvla123`, seeded with the `Admin` role).

## Test plan

- [x] `docker compose -f docker-compose.yml config` — validates cleanly, env substitution resolves as expected.
- [x] `php artisan test` — 32/33 passing (only failure is the pre-existing unrelated `Tests\Feature\ExampleTest`); this change touches no application code.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ofstUcFpKNaAsr52Z13sH)_